### PR TITLE
Add updated_at field to ThreadInfo and PgCheckpointer for improved ti…

### DIFF
--- a/agentflow/checkpointer/pg_checkpointer.py
+++ b/agentflow/checkpointer/pg_checkpointer.py
@@ -1415,6 +1415,7 @@ class PgCheckpointer(BaseCheckpointer[StateT]):
                     user_id=user_id,
                     metadata=meta_dict,
                     run_id=meta_dict.get("run_id"),
+                    updated_at=row["updated_at"] if row else None,
                 )
 
             logger.debug("Thread not found for thread_id=%s, user_id=%s", thread_id, user_id)

--- a/agentflow/utils/thread_info.py
+++ b/agentflow/utils/thread_info.py
@@ -11,7 +11,7 @@ Classes:
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ThreadInfo(BaseModel):
@@ -35,5 +35,5 @@ class ThreadInfo(BaseModel):
     thread_name: str | None = None
     user_id: int | str | None = None
     metadata: dict[str, Any] | None = None
-    updated_at: datetime | None = None
+    updated_at: datetime | None = Field(default_factory=datetime.now)
     run_id: str | None = None

--- a/changelogs.md
+++ b/changelogs.md
@@ -7,3 +7,8 @@ Fixes
 1. Parallel tool calls for invoke methods
 2. Fixed ID generation for 'int' and 'bigint' types
 3. Updated logging to use specific logger names
+
+
+Version: 0.5.1 later
+1. Fixed timestamp handling in PgCheckpointer to avoid validation errors
+2. Added updated_at field when reconstructing threads in PgCheckpointer


### PR DESCRIPTION
This pull request focuses on improving timestamp handling for threads in the `PgCheckpointer` and updating the `ThreadInfo` model to avoid validation errors and ensure accurate tracking of updates. The main changes involve using a default timestamp for the `updated_at` field and ensuring this field is properly set when reconstructing threads.

**Thread timestamp handling improvements:**

* [`agentflow/utils/thread_info.py`](diffhunk://#diff-2d59c33ee4eac6b717d4a4203356a2e3f4500aec58e9f64c063d6f96a2d90ed7L38-R38): Changed the `updated_at` field in the `ThreadInfo` model to use `Field(default_factory=datetime.now)` for automatic timestamp assignment, preventing validation errors when the field is missing.
* [`agentflow/utils/thread_info.py`](diffhunk://#diff-2d59c33ee4eac6b717d4a4203356a2e3f4500aec58e9f64c063d6f96a2d90ed7L14-R14): Imported `Field` from `pydantic` to support the new default behavior for `updated_at`.
* [`agentflow/checkpointer/pg_checkpointer.py`](diffhunk://#diff-576beaf60e4bb3f959fc530c62134009819046c8342c7418699f12d16039f740R1418): Added logic to set the `updated_at` field when reconstructing a thread from the database, ensuring the timestamp is preserved.

**Documentation updates:**

* [`changelogs.md`](diffhunk://#diff-092d42085593fd7f01aab872321d7afcfb303bdafd278201d1c6b596f0695873R10-R14): Documented the fixes for timestamp handling and the addition of the `updated_at` field in the changelog under version 0.5.1.