### PR TITLE
fix: Improve interrupt handling in MCP and Stream execution flow

### DIFF
--- a/agentflow/graph/tool_node/executors.py
+++ b/agentflow/graph/tool_node/executors.py
@@ -704,7 +704,7 @@ class MCPMixin:
                     )
         return tools
 
-    async def _mcp_execute(
+    async def _mcp_execute(  # noqa: PLR0915
         self,
         name: str,
         args: dict,

--- a/agentflow/graph/utils/stream_handler.py
+++ b/agentflow/graph/utils/stream_handler.py
@@ -524,6 +524,8 @@ class StreamHandler[StateT: AgentState](
                 event.content_type = [ContentType.STATE, ContentType.MESSAGE]
                 publish_event(event)
 
+                is_interrupted_requested = False
+
                 # Check for interrupt_after
                 if await self._check_and_handle_interrupt(
                     current_node,
@@ -536,6 +538,8 @@ class StreamHandler[StateT: AgentState](
                     if next_node is None:
                         next_node = get_next_node(current_node, state, self.edges)
                     state.set_current_node(next_node)
+
+                    is_interrupted_requested = True
 
                     event.event_type = EventType.INTERRUPTED
                     event.data["interrupted"] = "After"
@@ -555,7 +559,6 @@ class StreamHandler[StateT: AgentState](
                         thread_id=config.get("thread_id"),
                         run_id=config.get("run_id"),
                     )
-                    return
 
                 # Get next node
                 if next_node is None:
@@ -587,6 +590,9 @@ class StreamHandler[StateT: AgentState](
                     thread_id=config.get("thread_id"),
                     run_id=config.get("run_id"),
                 )
+
+                if is_interrupted_requested:
+                    return
 
                 if step >= max_steps:
                     error_msg = "Graph execution exceeded maximum steps"

--- a/changelogs.md
+++ b/changelogs.md
@@ -1,3 +1,6 @@
+Version: 0.5.4 - 0.5.5
+1. Fix minor bugs in MCP and Node execution with interrupt handling
+
 Version: 0.5.3 later
 1. Enhanced MCP Tool Execution to Include User Information in Input Data
 2. Created AgentClass for Simplified Agent Instantiation


### PR DESCRIPTION
This pull request focuses on improving interrupt handling during graph execution, particularly in MCP and Node execution flows. The main changes ensure that when an interrupt is requested after a node execution, the process exits immediately and returns the current state, preventing further unnecessary steps and clarifying the control flow. Minor bugs related to interrupt handling are also addressed.

Improvements to interrupt handling:

* Updated both `invoke_handler.py` and `stream_handler.py` so that when an interrupt is requested after node execution, the execution exits immediately by checking the new `is_interrupted_requested` flag and returning the current state and messages. This prevents further processing after an interrupt. [[1]](diffhunk://#diff-c0c1b16b47523f0f3b5c42716a099712febb9498785a1cefa16f0f3a254767eeR390-R391) [[2]](diffhunk://#diff-c0c1b16b47523f0f3b5c42716a099712febb9498785a1cefa16f0f3a254767eeR404-L408) [[3]](diffhunk://#diff-c0c1b16b47523f0f3b5c42716a099712febb9498785a1cefa16f0f3a254767eeR430-R433) [[4]](diffhunk://#diff-9fd4715777fb1c012c103ff489c7bfa2b95176db4c5511b8f58a06cd5068c80cR527-R528) [[5]](diffhunk://#diff-9fd4715777fb1c012c103ff489c7bfa2b95176db4c5511b8f58a06cd5068c80cR542-R543) [[6]](diffhunk://#diff-9fd4715777fb1c012c103ff489c7bfa2b95176db4c5511b8f58a06cd5068c80cL558) [[7]](diffhunk://#diff-9fd4715777fb1c012c103ff489c7bfa2b95176db4c5511b8f58a06cd5068c80cR594-R596)

Code and documentation updates:

* Added a changelog entry for version 0.5.4 - 0.5.5 documenting the bug fixes in MCP and Node execution related to interrupt handling.
* Minor refactoring in `executors.py` to update the `_mcp_execute` method signature, likely for consistency with linting or style guidelines.