### PR TITLE
fix: Enhance error handling in PgCheckpointer and update thread name …

### DIFF
--- a/changelogs.md
+++ b/changelogs.md
@@ -1,3 +1,7 @@
+Version: 0.5.6 later
+2. Improved Error Handling in PgCheckpointer Methods and if thread name is null during update
+then default to existing name and it will return is created or not
+
 Version: 0.5.4 - 0.5.5
 1. Fix minor bugs in MCP and Node execution with interrupt handling
 


### PR DESCRIPTION
This pull request updates the `PgCheckpointer`'s thread storage logic to provide clearer feedback on whether a thread was newly created or updated, and improves error handling. It also adds new tests to ensure the correct behavior of these changes.

**Enhancements to thread storage and update logic:**

* The `aput_thread` method now returns a boolean indicating if a thread was newly created (`True`) or if an existing thread was updated (`False`). The logic first attempts to insert, and if the thread already exists, it updates only the necessary fields, defaulting to the existing thread name if none is provided. [[1]](diffhunk://#diff-576beaf60e4bb3f959fc530c62134009819046c8342c7418699f12d16039f740L1324-R1325) [[2]](diffhunk://#diff-576beaf60e4bb3f959fc530c62134009819046c8342c7418699f12d16039f740L1346-R1398) [[3]](diffhunk://#diff-576beaf60e4bb3f959fc530c62134009819046c8342c7418699f12d16039f740L1335-R1336)

**Improved error handling:**

* Exception handling in both `aput_thread` and `_get_thread` now consistently raises the original exception object for better traceability. [[1]](diffhunk://#diff-576beaf60e4bb3f959fc530c62134009819046c8342c7418699f12d16039f740L1346-R1398) [[2]](diffhunk://#diff-576beaf60e4bb3f959fc530c62134009819046c8342c7418699f12d16039f740L1426-R1457)

**Testing and documentation:**

* New and updated tests verify the new return value of `aput_thread` and its behavior on both insert and update paths.
* The changelog has been updated to document these improvements and clarify the new behavior.