### PR TITLE
Fix failing sequential tool calls

### DIFF
--- a/agentflow/core/graph/agent_internal/execution.py
+++ b/agentflow/core/graph/agent_internal/execution.py
@@ -328,15 +328,14 @@ class AgentExecutionMixin:
 
         is_stream = config.get("is_stream", False)
 
-        if state.context and state.context[-1].role == "tool":
-            response = await self._call_llm_with_retry(messages=messages, stream=is_stream)
-        else:
-            tools = await self._resolve_tools(container)
-            response = await self._call_llm_with_retry(
-                messages=messages,
-                tools=tools if tools else None,
-                stream=is_stream,
-            )
+        # Always resolve tools - even after tool results, the model may want to call
+        # additional tools (e.g., Gemini 2.5+ with sequential tool calls)
+        tools = await self._resolve_tools(container)
+        response = await self._call_llm_with_retry(
+            messages=messages,
+            tools=tools if tools else None,
+            stream=is_stream,
+        )
 
         converter_key = self._get_converter_key()
         return ModelResponseConverter(response, converter=converter_key)

--- a/agentflow/runtime/protocols/a2a/_optional.py
+++ b/agentflow/runtime/protocols/a2a/_optional.py
@@ -8,8 +8,7 @@ from typing import Any
 
 
 A2A_EXTRA_INSTALL_HINT = (
-    "Install it with 'pip install 10xscale-agentflow[a2a_sdk]' "
-    "or 'pip install a2a-sdk'."
+    "Install it with 'pip install 10xscale-agentflow[a2a_sdk]' " "or 'pip install a2a-sdk'."
 )
 
 


### PR DESCRIPTION
Fixes  #92

This pull request contains a minor formatting update and a logic change to tool resolution in agent execution. The most significant change ensures that tools are always resolved, allowing for sequential tool calls even after tool results are returned.

Agent execution logic:

* Updated `execute` method in `agent_internal/execution.py` to always resolve tools, enabling support for models (such as Gemini 2.5+) that may call additional tools sequentially after initial tool results.

Formatting:

* Reformatted the `A2A_EXTRA_INSTALL_HINT` string in `_optional.py` for consistency and readability.