### PR TITLE
Vertex AI as a provider in the agent framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           # create venv in repo so it can be cached
-          python -m venv .venv
+          python -m venv --clear .venv
           source .venv/bin/activate
           pip install --upgrade pip
           uv sync --dev

--- a/agentflow/core/graph/agent.py
+++ b/agentflow/core/graph/agent.py
@@ -79,7 +79,7 @@ class Agent(
         llm_kwargs: Additional provider-specific parameters
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0912, PLR0913
         self,
         model: str,
         provider: str | None = None,

--- a/agentflow/core/graph/agent.py
+++ b/agentflow/core/graph/agent.py
@@ -268,6 +268,12 @@ class Agent(
             self.base_url = base_url
             self.client = self._create_client(self.provider, base_url)
 
+        # Normalize vertex_ai → google after client creation.
+        # Vertex AI uses the same google-genai SDK, so all downstream execution
+        # and message conversion logic works identically.
+        if self.provider == "vertex_ai":
+            self.provider = "google"
+
         # Validate that provider supports the output type
         self._validate_output_type()
 

--- a/agentflow/core/graph/agent_internal/providers.py
+++ b/agentflow/core/graph/agent_internal/providers.py
@@ -115,6 +115,31 @@ class AgentProviderMixin:
             logger.info("Creating Google GenAI Client with async support")
             return genai.Client(api_key=api_key)
 
+        if provider == "vertex_ai":
+            try:
+                from google import genai
+            except ImportError as exc:
+                raise ImportError(
+                    "google-genai SDK is required for Vertex AI provider. "
+                    "Install it with: pip install 10xscale-agentflow[google-genai]"
+                ) from exc
+
+            project = os.getenv("GOOGLE_CLOUD_PROJECT")
+            location = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+            if not project:
+                raise ValueError(
+                    "GOOGLE_CLOUD_PROJECT environment variable must be set "
+                    "for Vertex AI provider"
+                )
+
+            logger.info(
+                "Creating Google GenAI Client with Vertex AI (project=%s, location=%s)",
+                project,
+                location,
+            )
+            return genai.Client(vertexai=True, project=project, location=location)
+
         raise ValueError(
-            f"Unsupported provider: {provider}. " f"Supported providers: 'openai', 'google'"
+            f"Unsupported provider: {provider}. "
+            f"Supported providers: 'openai', 'google', 'vertex_ai'"
         )

--- a/examples/providers/google_react_sync.py
+++ b/examples/providers/google_react_sync.py
@@ -1,0 +1,75 @@
+"""Google GenAI provider example using a ReAct agent with tools.
+
+Prerequisites:
+    1. A Gemini API key from Google AI Studio (https://aistudio.google.com).
+    2. Environment variables (set in .env or shell):
+        GEMINI_API_KEY=<your-api-key>       # or GOOGLE_API_KEY
+"""
+
+from dotenv import load_dotenv
+
+from agentflow.core import Agent, StateGraph, ToolNode
+from agentflow.core.state import AgentState, Message
+from agentflow.storage.checkpointer import InMemoryCheckpointer
+from agentflow.utils.constants import END
+
+load_dotenv()
+
+checkpointer = InMemoryCheckpointer()
+
+
+def get_weather(location: str) -> str:
+    """Get the current weather for a specific location."""
+    return f"The weather in {location} is sunny"
+
+
+tool_node = ToolNode([get_weather])
+
+agent = Agent(
+    model="gemini-2.5-flash",
+    provider="google",
+    system_prompt=[{"role": "system", "content": "You are a helpful assistant."}],
+    trim_context=True,
+    reasoning_config=True,
+    tool_node=tool_node,
+)
+
+
+def should_use_tools(state: AgentState) -> str:
+    """Determine if we should use tools or end the conversation."""
+    if not state.context or len(state.context) == 0:
+        return "TOOL"
+
+    last_message = state.context[-1]
+
+    if (
+        hasattr(last_message, "tools_calls")
+        and last_message.tools_calls
+        and len(last_message.tools_calls) > 0
+        and last_message.role == "assistant"
+    ):
+        return "TOOL"
+
+    if last_message.role == "tool":
+        return "MAIN"
+
+    return END
+
+
+graph = StateGraph()
+graph.add_node("MAIN", agent)
+graph.add_node("TOOL", tool_node)
+graph.add_conditional_edges("MAIN", should_use_tools, {"TOOL": "TOOL", END: END})
+graph.add_edge("TOOL", "MAIN")
+graph.set_entry_point("MAIN")
+
+app = graph.compile(checkpointer=checkpointer)
+
+if __name__ == "__main__":
+    inp = {"messages": [Message.text_message("What is the weather in New York City?")]}
+    config = {"thread_id": "12345", "recursion_limit": 10}
+
+    res = app.invoke(inp, config=config)
+
+    for msg in res["messages"]:
+        print(f"[{msg.role}] {msg}")

--- a/examples/providers/vertex_ai_react_sync.py
+++ b/examples/providers/vertex_ai_react_sync.py
@@ -1,0 +1,78 @@
+"""Vertex AI provider example using a ReAct agent with tools.
+
+Prerequisites:
+    1. A GCP project with the Vertex AI API enabled.
+    2. A service account JSON key file.
+    3. Environment variables (set in .env or shell):
+        GOOGLE_CLOUD_PROJECT=<your-gcp-project-id>
+        GOOGLE_CLOUD_LOCATION=us-central1          # optional, defaults to us-central1
+        GOOGLE_APPLICATION_CREDENTIALS=./path/to/service_account.json
+"""
+
+from dotenv import load_dotenv
+
+from agentflow.core import Agent, StateGraph, ToolNode
+from agentflow.core.state import AgentState, Message
+from agentflow.storage.checkpointer import InMemoryCheckpointer
+from agentflow.utils.constants import END
+
+load_dotenv()
+
+checkpointer = InMemoryCheckpointer()
+
+
+def get_weather(location: str) -> str:
+    """Get the current weather for a specific location."""
+    return f"The weather in {location} is sunny"
+
+
+tool_node = ToolNode([get_weather])
+
+agent = Agent(
+    model="gemini-2.5-flash",
+    provider="vertex_ai",
+    system_prompt=[{"role": "system", "content": "You are a helpful assistant."}],
+    trim_context=True,
+    reasoning_config=True,
+    tool_node=tool_node,
+)
+
+
+def should_use_tools(state: AgentState) -> str:
+    """Determine if we should use tools or end the conversation."""
+    if not state.context or len(state.context) == 0:
+        return "TOOL"
+
+    last_message = state.context[-1]
+
+    if (
+        hasattr(last_message, "tools_calls")
+        and last_message.tools_calls
+        and len(last_message.tools_calls) > 0
+        and last_message.role == "assistant"
+    ):
+        return "TOOL"
+
+    if last_message.role == "tool":
+        return "MAIN"
+
+    return END
+
+
+graph = StateGraph()
+graph.add_node("MAIN", agent)
+graph.add_node("TOOL", tool_node)
+graph.add_conditional_edges("MAIN", should_use_tools, {"TOOL": "TOOL", END: END})
+graph.add_edge("TOOL", "MAIN")
+graph.set_entry_point("MAIN")
+
+app = graph.compile(checkpointer=checkpointer)
+
+if __name__ == "__main__":
+    inp = {"messages": [Message.text_message("What is the weather in New York City?")]}
+    config = {"thread_id": "12345", "recursion_limit": 10}
+
+    res = app.invoke(inp, config=config)
+
+    for msg in res["messages"]:
+        print(f"[{msg.role}] {msg}")


### PR DESCRIPTION
This pull request adds support for using Vertex AI as a provider in the agent framework, alongside Google GenAI, and introduces example scripts for both providers. The changes ensure that Vertex AI is handled seamlessly with the same SDK as Google GenAI, and provide clear user guidance for setup and usage.

**Vertex AI and Google GenAI provider support:**

* Added logic to normalize the `provider` value from `"vertex_ai"` to `"google"` in `MyState`, ensuring downstream logic treats both providers identically.
* Updated the `_create_client` method to support `"vertex_ai"` as a provider, including environment variable checks for GCP project and location, and instantiation of the GenAI client with Vertex AI settings. Improved error messages and updated the list of supported providers.

**Example scripts and documentation:**

* Added a new example script `examples/providers/vertex_ai_react_sync.py` demonstrating how to use a ReAct agent with tools via the Vertex AI provider, including setup instructions for GCP credentials.
* Added a new example script `examples/providers/google_react_sync.py` for using a ReAct agent with tools via the Google GenAI provider, with setup instructions for API keys.