### PR TITLE
Add JSON output type for Google and OpenAI

### DIFF
--- a/agentflow/core/graph/agent.py
+++ b/agentflow/core/graph/agent.py
@@ -96,6 +96,7 @@ class Agent(
         retry_config: RetryConfig | bool | None = True,
         fallback_models: list[str | tuple[str, str]] | None = None,
         multimodal_config: MultimodalConfig | None = None,
+        output_schema: Any | None = None,
         **kwargs,
     ):
         """Initialize an Agent node.
@@ -255,6 +256,8 @@ class Agent(
 
         # Store output type
         self.output_type = output_type.lower()
+        self.output_schema = output_schema
+        self._validate_output_schema_output_type()
 
         # Determine provider; self.llm_kwargs is set by super().__init__ and is
         # already available here for _create_client().
@@ -323,3 +326,15 @@ class Agent(
 
         # Multimodal configuration
         self.multimodal_config = multimodal_config
+
+    def _validate_output_schema_output_type(self) -> None:
+        """Validate compatibility between output_schema and output_type."""
+        if self.output_schema is None:
+            return
+
+        if self.output_type in {"image", "video", "audio"}:
+            raise ValueError(
+                "output_schema can only be used with text generation. "
+                "Use output_type='text' (or 'json' for legacy compatibility), "
+                "or remove output_schema for media generation."
+            )

--- a/agentflow/core/graph/agent_internal/constants.py
+++ b/agentflow/core/graph/agent_internal/constants.py
@@ -49,9 +49,9 @@ CALL_EXCLUDED_KWARGS = CLIENT_CONSTRUCTOR_KWARGS | frozenset(
     }
 )
 
-VALID_OUTPUT_TYPES = ("text", "image", "video", "audio")
-GOOGLE_OUTPUT_TYPES = ("text", "image", "video", "audio")
-OPENAI_OUTPUT_TYPES = ("text", "image", "audio")
+VALID_OUTPUT_TYPES = ("text", "image", "video", "audio", "json")
+GOOGLE_OUTPUT_TYPES = ("text", "image", "video", "audio", "json")
+OPENAI_OUTPUT_TYPES = ("text", "image", "audio", "json")
 
 GOOGLE_THINKING_BUDGET_BY_EFFORT = {
     "low": 512,

--- a/agentflow/core/graph/agent_internal/execution.py
+++ b/agentflow/core/graph/agent_internal/execution.py
@@ -251,6 +251,20 @@ class AgentExecutionMixin:
 
         if self.provider == "openai":
             if self.api_style == "responses":
+                if getattr(self, "output_schema", None):
+                    logger.debug(
+                        "output_schema is set; using chat completions parse path "
+                        "instead of Responses API"
+                    )
+                    self._effective_api_style = "chat"
+                    if self.reasoning_config and self.reasoning_config.get("effort"):
+                        kwargs.setdefault("reasoning_effort", self.reasoning_config["effort"])
+                    if self.base_url and self.reasoning_config:
+                        existing_extra = kwargs.get("extra_body", {})
+                        existing_extra["reasoning"] = self.reasoning_config
+                        kwargs["extra_body"] = existing_extra
+                    return await self._call_openai(messages, tools, stream, **kwargs)
+
                 if self.base_url:
                     try:
                         result = await self._call_openai_responses(

--- a/agentflow/core/graph/agent_internal/google.py
+++ b/agentflow/core/graph/agent_internal/google.py
@@ -301,6 +301,8 @@ class AgentGoogleMixin:
         from google.genai import types
 
         config_kwargs = {}
+        structured_output = getattr(self, "output_schema", None) is not None
+        text_like_output = self.output_type in ("text", "json")
 
         if system_instruction:
             config_kwargs["system_instruction"] = system_instruction
@@ -313,7 +315,7 @@ class AgentGoogleMixin:
                 call_kwargs.pop("max_output_tokens", None),
             )
 
-        if tools and self.output_type == "text":
+        if tools and text_like_output and not structured_output:
             function_declarations = self._convert_tools_to_google_format(tools)
             if function_declarations:
                 config_kwargs["tools"] = [types.Tool(function_declarations=function_declarations)]
@@ -321,7 +323,8 @@ class AgentGoogleMixin:
         if (
             self.reasoning_config
             and isinstance(self.reasoning_config, dict)
-            and self.output_type == "text"
+            and text_like_output
+            and not structured_output
         ):
             thinking_kwargs: dict[str, Any] = {"include_thoughts": True}
             budget = self.reasoning_config.get("thinking_budget")
@@ -340,6 +343,39 @@ class AgentGoogleMixin:
 
         return types.GenerateContentConfig(**config_kwargs) if config_kwargs else None
 
+    async def _call_google_content_generation(
+        self,
+        google_contents: list,
+        config: Any,
+        stream: bool,
+        structured_output: bool,
+    ) -> Any:
+        """Call Google content generation endpoints for text or structured-json output."""
+        mode_suffix = " (json schema)" if structured_output else ""
+
+        if stream:
+            logger.debug(
+                "Calling Google aio.models.generate_content_stream%s with model=%s",
+                mode_suffix,
+                self.model,
+            )
+            return await self.client.aio.models.generate_content_stream(
+                model=self.model,
+                contents=google_contents,
+                config=config,
+            )
+
+        logger.debug(
+            "Calling Google aio.models.generate_content%s with model=%s",
+            mode_suffix,
+            self.model,
+        )
+        return await self.client.aio.models.generate_content(
+            model=self.model,
+            contents=google_contents,
+            config=config,
+        )
+
     async def _call_google(
         self,
         messages: list[dict[str, Any]],
@@ -348,28 +384,46 @@ class AgentGoogleMixin:
         **kwargs: Any,
     ) -> Any:
         """Call Google GenAI text, image, video, or audio endpoints."""
+        output_schema = getattr(self, "output_schema", None)
+        structured_output = output_schema is not None
+
+        if tools and structured_output:
+            raise ValueError(
+                "Google GenAI does not currently support combining tool calls (function calling) "
+                "with structured JSON outputs when output_schema is provided. "
+                "Please execute tools using plain text output, or separate your tool gathering "
+                "and structured extraction nodes."
+            )
+
         call_kwargs = {**self.llm_kwargs, **kwargs}
 
         system_instruction, google_contents = self._convert_to_google_format(messages)
         config = self._build_google_config(system_instruction, tools, call_kwargs)
 
-        if self.output_type == "text":
-            if stream:
-                logger.debug(
-                    "Calling Google aio.models.generate_content_stream with model=%s",
-                    self.model,
-                )
-                return await self.client.aio.models.generate_content_stream(
-                    model=self.model,
-                    contents=google_contents,
-                    config=config,
-                )
+        if structured_output:
+            if config is None:
+                from google.genai import types
 
-            logger.debug("Calling Google aio.models.generate_content with model=%s", self.model)
-            return await self.client.aio.models.generate_content(
-                model=self.model,
-                contents=google_contents,
-                config=config,
+                config = types.GenerateContentConfig(
+                    response_mime_type="application/json",
+                    response_schema=output_schema,
+                )
+            else:
+                config.response_mime_type = "application/json"
+                config.response_schema = output_schema
+            return await self._call_google_content_generation(
+                google_contents,
+                config,
+                stream,
+                structured_output=True,
+            )
+
+        if self.output_type in ("text", "json"):
+            return await self._call_google_content_generation(
+                google_contents,
+                config,
+                stream,
+                structured_output=False,
             )
 
         if self.output_type == "image":

--- a/agentflow/core/graph/agent_internal/openai.py
+++ b/agentflow/core/graph/agent_internal/openai.py
@@ -95,7 +95,21 @@ class AgentOpenAIMixin:
             if key not in CALL_EXCLUDED_KWARGS
         }
 
-        if self.output_type == "text":
+        output_schema = getattr(self, "output_schema", None)
+        if output_schema:
+            if tools:
+                call_kwargs["tools"] = tools
+
+            logger.debug("Calling OpenAI beta.chat.completions.parse with model=%s", self.model)
+            return await self.client.beta.chat.completions.parse(
+                model=self.model,
+                messages=messages,
+                response_format=output_schema,
+                stream=False,
+                **call_kwargs,
+            )
+
+        if self.output_type in ("text", "json"):
             if tools:
                 call_kwargs["tools"] = tools
 

--- a/agentflow/core/state/message.py
+++ b/agentflow/core/state/message.py
@@ -28,6 +28,7 @@ from datetime import datetime
 from typing import Any, Literal
 from uuid import uuid4
 
+import pydantic
 from injectq import InjectQ
 from pydantic import BaseModel, Field
 
@@ -160,6 +161,7 @@ class Message(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     usages: TokenUsages | None = None
     raw: dict[str, Any] | None = None
+    parsed_content: dict | pydantic.BaseModel | None = None
 
     @classmethod
     def text_message(

--- a/agentflow/runtime/adapters/llm/google_genai_converter.py
+++ b/agentflow/runtime/adapters/llm/google_genai_converter.py
@@ -94,6 +94,8 @@ class GoogleGenAIConverter(BaseConverter):
         if hasattr(response, "create_time") and response.create_time:
             created_date = response.create_time.timestamp()
 
+        parsed = getattr(response, "parsed", None)
+
         return Message(
             message_id=generate_id(getattr(response, "response_id", None)),
             role="assistant",
@@ -108,6 +110,7 @@ class GoogleGenAIConverter(BaseConverter):
             usages=usages,
             raw=None,  # Google GenAI responses are Pydantic models
             tools_calls=tools_calls if tools_calls else None,
+            parsed_content=parsed,
         )
 
     def _create_empty_message(self) -> Message:

--- a/agentflow/runtime/adapters/llm/openai_converter.py
+++ b/agentflow/runtime/adapters/llm/openai_converter.py
@@ -83,6 +83,7 @@ class OpenAIConverter(BaseConverter):
             return self._build_empty_response_message(response, usages)
 
         message = choice.message
+        parsed = getattr(message, "parsed", None)
         content, reasoning_content = self._extract_message_text_and_reasoning(message)
         blocks = self._build_response_blocks(message, content, reasoning_content)
         final_tool_calls = self._append_tool_call_blocks(message, blocks)
@@ -94,6 +95,7 @@ class OpenAIConverter(BaseConverter):
             role=message.role,
             content=blocks,
             reasoning=reasoning_content,
+            parsed_content=parsed,
             timestamp=getattr(response, "created", datetime.now().timestamp()),
             metadata={
                 "provider": "openai",


### PR DESCRIPTION
This pull request adds support for structured output schemas for text and JSON generation in both OpenAI and Google GenAI agents, along with improved validation and handling of output types. It also introduces a new `parsed_content` field on messages to store parsed model outputs, and ensures compatibility checks between output schema and output type. The most important changes are:

**Structured Output Schema Support:**

* Added an `output_schema` parameter to the agent initialization, allowing users to specify a schema for structured outputs (e.g., JSON) (`agentflow/core/graph/agent.py`).
* Implemented logic in OpenAI and Google GenAI adapters to use the schema for parsing model outputs and to route requests appropriately based on the presence of `output_schema` (`agentflow/core/graph/agent_internal/openai.py`, `agentflow/core/graph/agent_internal/google.py`, `agentflow/core/graph/agent_internal/execution.py`). [[1]](diffhunk://#diff-c14055d8309966d71807222c92629294b7e68eb3d788da4657baf196e21311c8L98-R112) [[2]](diffhunk://#diff-e3191b678bfb7cbad630798c0122a01b62134f674c62fc09a90c492e2f3d7135R304-R305) [[3]](diffhunk://#diff-5f912845e21fcbe7c2f2e8ca4479c83ac0b6a1d6645f47a73eaa2e60dd0e0e98R254-R267)

**Output Type Handling and Validation:**

* Extended valid output types to include `"json"` and added validation to ensure that `output_schema` is only used with text-like outputs, raising errors if used with media types (`agentflow/core/graph/agent_internal/constants.py`, `agentflow/core/graph/agent.py`). [[1]](diffhunk://#diff-b69d16948c776594230d7d74ddce1c70bd586dc66c3ddf37e248767806f12ce9L52-R54) [[2]](diffhunk://#diff-966944a75f24a797e49633924627d273f6edbb19c36f965ec2f91009d1f52ab1R329-R340) [[3]](diffhunk://#diff-966944a75f24a797e49633924627d273f6edbb19c36f965ec2f91009d1f52ab1R259-R260)

**Message Parsing and Storage:**

* Added a new `parsed_content` field to the `Message` model to store parsed outputs from model responses, and updated OpenAI and Google GenAI converters to populate this field (`agentflow/core/state/message.py`, `agentflow/runtime/adapters/llm/openai_converter.py`, `agentflow/runtime/adapters/llm/google_genai_converter.py`). [[1]](diffhunk://#diff-f3523aacf8cd606492ba8abed61e10f0a22fd807612dfb6077a5e292ecd946d9R164) [[2]](diffhunk://#diff-70f45a11f004e3db319bb99420935336e4c0a4e583561241d8ef4a3d994a1e86R113) [[3]](diffhunk://#diff-f1da75d95e676f323301a9a40921c9d5ecf9dfc5cba88a0b6ed72358d76b1b7fR98)

**Adapter and API Changes:**

* Refactored the Google GenAI call logic to separate structured (JSON) and unstructured (text) output paths, and added error handling for unsupported combinations (e.g., tools with structured output) (`agentflow/core/graph/agent_internal/google.py`).

**Dependency and Import Updates:**

* Added missing imports for `pydantic` to support the new message field (`agentflow/core/state/message.py`).