### PR TITLE
feat: introduce StreamEmitter for live progress updates during tool e…

### DIFF
--- a/agentflow/core/graph/tool_node/base.py
+++ b/agentflow/core/graph/tool_node/base.py
@@ -30,6 +30,7 @@ from injectq import Inject
 
 from agentflow.core.state import AgentState, ErrorBlock, Message, ToolCallBlock, ToolResultBlock
 from agentflow.core.state.message_block import RemoteToolCallBlock
+from agentflow.core.state.stream_emitter import StreamEmitter
 from agentflow.runtime.adapters.tools import ComposioAdapter
 from agentflow.runtime.publisher.events import ContentType, Event, EventModel, EventType
 from agentflow.runtime.publisher.publish import publish_event
@@ -493,6 +494,7 @@ class ToolNode(
         tool_call_id: str,
         config: dict[str, t.Any],
         state: AgentState,
+        emit: StreamEmitter | None = None,
         callback_manager: CallbackManager = Inject[CallbackManager],
     ) -> t.AsyncIterator[Message | dict[str, t.Any]]:
         """Execute a tool with streaming support, yielding incremental results.
@@ -629,6 +631,7 @@ class ToolNode(
                 config,
                 state,
                 callback_manager,
+                emit=emit,
             )
             if isinstance(result, Message):
                 event.data["message"] = result.model_dump()

--- a/agentflow/core/graph/tool_node/constants.py
+++ b/agentflow/core/graph/tool_node/constants.py
@@ -39,6 +39,7 @@ INJECTABLE_PARAMS = {
     "tool_call_id",
     "state",
     "config",
+    "emit",
     "generated_id",
     "context_manager",
     "publisher",

--- a/agentflow/core/graph/tool_node/executors.py
+++ b/agentflow/core/graph/tool_node/executors.py
@@ -23,6 +23,12 @@ from agentflow.utils import CallbackContext, CallbackManager, InvocationType, ca
 from .constants import INJECTABLE_PARAMS, has_injected_default
 
 
+# Sentinel-import: StreamEmitter is imported lazily to avoid circular deps at
+# module load time; the type hint is only used in method signatures.
+if t.TYPE_CHECKING:
+    from agentflow.core.state.stream_emitter import StreamEmitter
+
+
 logger = logging.getLogger("agentflow.graph.tool_node")
 
 
@@ -395,7 +401,7 @@ class LocalExecMixin:
             ):
                 continue
 
-            if param_name in ["state", "config", "tool_call_id"]:
+            if param_name in default_data:
                 input_data[param_name] = default_data[param_name]
                 continue
 
@@ -515,6 +521,7 @@ class LocalExecMixin:
         config: dict[str, t.Any],
         state: AgentState,
         callback_mgr: CallbackManager,
+        emit: StreamEmitter | None = None,
     ) -> dict[str, t.Any] | Message:
         context = CallbackContext(
             invocation_type=InvocationType.TOOL,
@@ -536,6 +543,7 @@ class LocalExecMixin:
                 "tool_call_id": tool_call_id,
                 "state": state,
                 "config": config,
+                "emit": emit,
             },
         )
 

--- a/agentflow/core/graph/utils/stream_node_handler.py
+++ b/agentflow/core/graph/utils/stream_node_handler.py
@@ -25,6 +25,7 @@ from agentflow.core.graph.utils.utils import process_node_result
 from agentflow.core.state import AgentState, Message
 from agentflow.core.state.message_block import ErrorBlock
 from agentflow.core.state.stream_chunks import StreamChunk, StreamEvent
+from agentflow.core.state.stream_emitter import StreamEmitter
 from agentflow.prebuilt.tools.handoff import is_handoff_tool
 from agentflow.runtime.adapters.llm.model_response_converter import ModelResponseConverter
 from agentflow.runtime.publisher.events import ContentType, Event, EventModel, EventType
@@ -111,40 +112,59 @@ class StreamNodeHandler(BaseLoggingMixin):
             run_id=config.get("run_id"),
         )
 
-        # Execute the tool function with injectable parameters
-        tool_result_gen = self.func.stream(  # type: ignore
-            function_name,  # type: ignore
-            function_args,
+        # Create a per-tool queue.  The StreamEmitter pushes chunks into this
+        # queue from the tool (including from sync-tool threads); the background
+        # task pushes the final tool result(s); we drain the queue and yield
+        # items live so the frontend sees progress before the tool finishes.
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+        _DONE = object()  # sentinel
+
+        emitter = StreamEmitter(
+            tool_name=function_name,
             tool_call_id=tool_call_id,
-            state=state,
-            config=config,
-        )
-        logger.debug("Node '%s' tool execution completed successfully", self.name)
-        yield StreamChunk(
-            event=StreamEvent.UPDATES,
-            data={
-                "status": "tool_invoked",
-                "tool_name": function_name,
-                "args": function_args,
-                "tool_call_id": tool_call_id,
-                "node": self.name,
-            },
+            node_name=self.name,
             thread_id=config.get("thread_id"),
             run_id=config.get("run_id"),
+            queue=queue,
+            loop=loop,
         )
 
-        async for result in tool_result_gen:
-            if isinstance(result, dict):
+        async def _run_tool() -> None:
+            try:
+                async for result in self.func.stream(  # type: ignore[union-attr]
+                    function_name,
+                    function_args,
+                    tool_call_id=tool_call_id,
+                    state=state,
+                    config=config,
+                    emit=emitter,
+                ):
+                    await queue.put(result)
+            finally:
+                await queue.put(_DONE)
+
+        task = asyncio.create_task(_run_tool())
+
+        while True:
+            item = await queue.get()
+            if item is _DONE:
+                break
+
+            if isinstance(item, StreamChunk):
+                # Already a StreamChunk (e.g. emitted by the tool via StreamEmitter)
+                yield item
+            elif isinstance(item, dict):
                 # Dict result from ToolResult (state update) — yield the message
                 # and pass the dict through so the consumer can handle state merging
-                msg = result.get("messages")
+                msg = item.get("messages")
                 if isinstance(msg, Message):
                     yield msg
                     yield StreamChunk(
                         event=StreamEvent.MESSAGE,
                         message=msg,
                         data={
-                            "status": "tool_invoked",
+                            "status": "tool_result",
                             "tool_name": function_name,
                             "args": function_args,
                             "tool_call_id": tool_call_id,
@@ -154,26 +174,26 @@ class StreamNodeHandler(BaseLoggingMixin):
                         run_id=config.get("run_id"),
                     )
                 # Yield the raw dict so upstream can merge state
-                yield result
-            elif isinstance(result, Message):
-                yield result
+                yield item
+            elif isinstance(item, Message):
+                yield item
                 is_error = (
-                    any(isinstance(block, ErrorBlock) for block in result.content)
-                    if isinstance(result.content, list)
+                    any(isinstance(block, ErrorBlock) for block in item.content)
+                    if isinstance(item.content, list)
                     else False
                 )
                 if is_error:
                     yield StreamChunk(
                         event=StreamEvent.ERROR,
                         data={
-                            "status": "tool_invoked",
+                            "status": "tool_failed",
                             "tool_name": function_name,
                             "args": function_args,
                             "tool_call_id": tool_call_id,
                             "node": self.name,
                             "reason": "Tool execution resulted in error",
                             "error": next(
-                                block for block in result.content if isinstance(block, ErrorBlock)
+                                block for block in item.content if isinstance(block, ErrorBlock)
                             ).message,
                         },
                         thread_id=config.get("thread_id"),
@@ -182,9 +202,9 @@ class StreamNodeHandler(BaseLoggingMixin):
                 else:
                     yield StreamChunk(
                         event=StreamEvent.MESSAGE,
-                        message=result,
+                        message=item,
                         data={
-                            "status": "tool_invoked",
+                            "status": "tool_result",
                             "tool_name": function_name,
                             "args": function_args,
                             "tool_call_id": tool_call_id,
@@ -194,7 +214,10 @@ class StreamNodeHandler(BaseLoggingMixin):
                         run_id=config.get("run_id"),
                     )
             else:
-                yield result
+                yield item
+
+        # Re-raise any exception that occurred inside the background task.
+        await task
 
     async def _call_tools(
         self,
@@ -208,7 +231,7 @@ class StreamNodeHandler(BaseLoggingMixin):
             and last_message.tools_calls
             and len(last_message.tools_calls) > 0
         ):
-            # NEW: Check for handoff BEFORE executing any tools
+            # Check for handoff BEFORE executing any tools
             for tool_call in last_message.tools_calls:
                 tool_name = tool_call.get("function", {}).get("name", "")
                 is_handoff, target_agent = is_handoff_tool(tool_name)
@@ -220,45 +243,50 @@ class StreamNodeHandler(BaseLoggingMixin):
                         tool_name,
                         target_agent,
                     )
-
-                    # Yield Command for streaming context
                     yield Command(  # type: ignore
                         update=None,
                         goto=target_agent,
                     )
-                    return  # Stop processing
+                    return
 
-            # Continue with normal tool execution if no handoff detected
-            # Execute tool calls in parallel
             logger.info(
                 "Node '%s' executing %d tool calls in parallel",
                 self.name,
                 len(last_message.tools_calls),
             )
 
-            # Create async generators for all tool calls
+            # Shared output queue — all parallel tool workers push here so items
+            # are yielded as soon as they are available, not after all tools finish.
+            shared_queue: asyncio.Queue = asyncio.Queue()
+            _WORKER_DONE = object()  # per-worker sentinel
+
             generators = [
                 self._handle_single_tool(tool_call, state, config)
                 for tool_call in last_message.tools_calls
             ]
 
-            # Use asyncio.gather to collect all results from generators
-            async def collect_from_generator(gen):
-                results = []
-                async for result in gen:
-                    # all results
-                    results.append(result)
-                return results
+            async def _worker(gen: AsyncIterable) -> None:
+                try:
+                    async for item in gen:
+                        await shared_queue.put(item)
+                finally:
+                    await shared_queue.put(_WORKER_DONE)
 
-            # Execute all tool calls concurrently
-            all_results = await asyncio.gather(*[collect_from_generator(gen) for gen in generators])
+            tasks = [asyncio.create_task(_worker(gen)) for gen in generators]
+            remaining = len(tasks)
 
-            # Yield all results (they come in order of completion, not call order)
-            for results in all_results:
-                for result in results:
-                    yield result
+            while remaining > 0:
+                item = await shared_queue.get()
+                if item is _WORKER_DONE:
+                    remaining -= 1
+                else:
+                    yield item
+
+            # Re-raise the first exception from any worker task.
+            for task in tasks:
+                await task
+
         else:
-            # No tool calls to execute, return available tools
             logger.exception("Node '%s': No tool calls to execute", self.name)
             raise NodeError(
                 message="No tool calls to execute",

--- a/agentflow/core/state/__init__.py
+++ b/agentflow/core/state/__init__.py
@@ -38,6 +38,7 @@ from .reducers import (
     replace_value,
 )
 from .stream_chunks import StreamChunk, StreamEvent
+from .stream_emitter import StreamEmitter
 from .tool_result import ToolResult
 
 
@@ -59,6 +60,7 @@ __all__ = [
     "MessageContextManager",
     "ReasoningBlock",
     "StreamChunk",
+    "StreamEmitter",
     "StreamEvent",
     "TextBlock",
     "TextBlock",

--- a/agentflow/core/state/stream_emitter.py
+++ b/agentflow/core/state/stream_emitter.py
@@ -1,0 +1,148 @@
+"""StreamEmitter for injecting live progress chunks into graph stream output.
+
+This module provides the StreamEmitter class, which can be optionally injected
+into tool functions during streaming execution. It allows tools to emit progress,
+error, and status updates that appear directly in the ``app.stream(...)`` /
+``app.astream(...)`` output consumed by the frontend.
+
+StreamEmitter has no effect during ``invoke(...)`` / ``ainvoke(...)``; in that
+path, tools receive ``emit=None`` (or the parameter is absent).
+
+Thread safety: emit methods use ``loop.call_soon_threadsafe`` so they work
+correctly from sync tools running inside ``asyncio.to_thread``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from .stream_chunks import StreamChunk, StreamEvent
+
+
+class StreamEmitter:
+    """Inject into tool functions during streaming to emit live stream chunks.
+
+    Create one emitter per tool call. Bind it to an ``asyncio.Queue`` owned by
+    the streaming handler. The handler drains the queue and yields chunks to the
+    caller of ``app.stream(...)`` / ``app.astream(...)``.
+
+    Attributes:
+        tool_name: Name of the tool being executed.
+        tool_call_id: Unique identifier for this tool invocation.
+        node_name: Name of the graph node executing the tool.
+        thread_id: Active thread/session identifier (from config).
+        run_id: Active run identifier (from config).
+
+    Example::
+
+        def get_weather(
+            location: str,
+            tool_call_id: str | None = None,
+            emit: StreamEmitter | None = None,
+        ) -> str:
+            if emit:
+                emit.progress("Fetching weather data...", data={"location": location})
+            result = _fetch(location)
+            return result
+    """
+
+    def __init__(
+        self,
+        *,
+        tool_name: str,
+        tool_call_id: str,
+        node_name: str,
+        thread_id: str | None,
+        run_id: str | None,
+        queue: asyncio.Queue,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        self._tool_name = tool_name
+        self._tool_call_id = tool_call_id
+        self._node_name = node_name
+        self._thread_id = thread_id
+        self._run_id = run_id
+        self._queue = queue
+        self._loop = loop
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _emit(self, event: StreamEvent, data: dict) -> None:
+        """Build a StreamChunk and schedule it on the event loop thread-safely."""
+        chunk = StreamChunk(
+            event=event,
+            data=data,
+            thread_id=self._thread_id,
+            run_id=self._run_id,
+        )
+        # call_soon_threadsafe is safe from both thread-pool threads (sync tools
+        # running in asyncio.to_thread) and from the event loop itself.
+        self._loop.call_soon_threadsafe(self._queue.put_nowait, chunk)
+
+    def _base_data(self, extra: dict | None) -> dict:
+        base = {
+            "tool_name": self._tool_name,
+            "tool_call_id": self._tool_call_id,
+            "node": self._node_name,
+        }
+        if extra:
+            base.update(extra)
+        return base
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def progress(self, message: str, data: dict | None = None) -> None:
+        """Emit a progress update for the running tool.
+
+        This chunk uses ``StreamEvent.MESSAGE`` so it is visible at all
+        ``ResponseGranularity`` levels including the default ``LOW`` level.
+
+        Args:
+            message: Human-readable description of the current step.
+            data: Optional extra key-value pairs included in the chunk data
+                  (e.g. ``{"attempt": 1, "max_attempts": 3}``).
+        """
+        payload = self._base_data(data)
+        payload["status"] = "tool_progress"
+        payload["message"] = message
+        self._emit(StreamEvent.MESSAGE, payload)
+
+    def error(self, message: str, data: dict | None = None) -> None:
+        """Emit an error update for the running tool.
+
+        The tool result is still returned normally after this call; this chunk
+        is informational and does not interrupt execution.
+
+        Args:
+            message: Human-readable description of the error.
+            data: Optional extra key-value pairs included in the chunk data.
+        """
+        payload = self._base_data(data)
+        payload["status"] = "tool_failed"
+        payload["message"] = message
+        self._emit(StreamEvent.ERROR, payload)
+
+    def message(self, message: str, data: dict | None = None) -> None:
+        """Emit a plain message update from the running tool.
+
+        Args:
+            message: Human-readable message text.
+            data: Optional extra key-value pairs included in the chunk data.
+        """
+        payload = self._base_data(data)
+        payload["status"] = "tool_message"
+        payload["message"] = message
+        self._emit(StreamEvent.MESSAGE, payload)
+
+    def update(self, data: dict) -> None:
+        """Emit a generic data update from the running tool.
+
+        Args:
+            data: Arbitrary key-value pairs to include in the stream chunk.
+        """
+        payload = self._base_data(data)
+        self._emit(StreamEvent.UPDATES, payload)

--- a/docs/stream-emitter-plan.md
+++ b/docs/stream-emitter-plan.md
@@ -1,0 +1,294 @@
+# StreamEmitter Plan
+
+## Goal
+
+Add a `StreamEmitter` that is automatically injected into tool calls during streaming execution. Tools can use it to emit progress, status, message, and error updates to the same `app.stream(...)` / `app.astream(...)` output that the frontend already consumes.
+
+This feature must have no effect on normal `invoke(...)` / `ainvoke(...)` calls.
+
+## Problem
+
+Today, tool execution can publish events through the publisher system, but frontend clients usually cannot consume Redis, Kafka, RabbitMQ, or other backend publishers directly.
+
+Also, a local tool such as `get_weather(...)` runs like a normal function. If it retries internally, the graph stream does not see those intermediate retry states. The frontend only receives the final tool result.
+
+The desired behavior is:
+
+1. A tool starts running in streaming mode.
+2. The tool emits progress while it runs.
+3. The frontend receives those updates through the existing graph stream.
+4. The final tool result is still returned normally.
+5. Non-streaming invoke behavior remains unchanged.
+
+## API Shape
+
+Tools should be able to accept an optional injected `emit` parameter:
+
+```python
+def get_weather(
+    location: str,
+    tool_call_id: str | None = None,
+    state: CustomAgentState | None = None,
+    emit: StreamEmitter | None = None,
+) -> str:
+    ...
+```
+
+Example usage:
+
+```python
+if emit:
+    emit.progress(
+        "Attempt 1 failed. Retrying...",
+        data={"attempt": 1, "max_attempts": 3},
+    )
+```
+
+Final failure can be emitted as:
+
+```python
+if emit:
+    emit.error(
+        "Weather lookup failed after 3 attempts.",
+        data={"location": location},
+    )
+```
+
+## StreamEmitter Responsibilities
+
+Create a class called `StreamEmitter`.
+
+It should provide sync-friendly methods:
+
+```python
+emit.progress(message: str, data: dict | None = None) -> None
+emit.error(message: str, data: dict | None = None) -> None
+emit.message(message: str, data: dict | None = None) -> None
+emit.update(data: dict) -> None
+```
+
+The methods should create `StreamChunk` objects and push them into the active streaming output path.
+
+The emitted chunks should include useful metadata:
+
+```python
+{
+    "status": "tool_progress",
+    "message": "...",
+    "tool_name": "get_weather",
+    "tool_call_id": "call_abc",
+    "node": "TOOL",
+    "attempt": 1,
+    "max_attempts": 3,
+}
+```
+
+## Streaming Behavior
+
+During `app.stream(...)` / `app.astream(...)`:
+
+1. `StreamNodeHandler` detects a tool call.
+2. It creates a queue for emitted stream chunks.
+3. It creates a `StreamEmitter` bound to that queue and tool context.
+4. It passes the emitter into `ToolNode.stream(...)`.
+5. `ToolNode.stream(...)` passes the emitter into `_internal_execute(...)`.
+6. `_internal_execute(...)` injects `emit` into the tool function if requested.
+7. While the tool runs, emitted chunks are yielded to the graph stream.
+8. When the tool finishes, the normal tool result is yielded as before.
+
+## Invoke Behavior
+
+Regular `invoke(...)` / `ainvoke(...)` should not create or inject an active emitter.
+
+Options:
+
+1. Do not inject `emit` in the invoke path.
+2. Inject `emit=None` in the invoke path.
+3. Inject a no-op emitter in the invoke path.
+
+Recommended: inject `emit=None` or do not inject it at all for invoke. This makes it clear that custom streaming updates are only available in streaming mode.
+
+## Files To Update
+
+### `agentflow/core/state/stream_emitter.py`
+
+Add the new `StreamEmitter` class.
+
+It should know:
+
+```python
+tool_name
+tool_call_id
+node_name
+thread_id
+run_id
+queue        # asyncio.Queue
+loop         # asyncio.AbstractEventLoop, captured at construction
+```
+
+It should build `StreamChunk` values using:
+
+```python
+StreamEvent.UPDATES
+StreamEvent.ERROR
+StreamEvent.MESSAGE
+```
+
+**Thread safety:** All emit methods must use `loop.call_soon_threadsafe(queue.put_nowait, chunk)` instead of `queue.put_nowait(chunk)` directly. Sync tools run inside `asyncio.to_thread(...)` on a thread-pool thread; calling `queue.put_nowait` directly from that thread is not safe. `call_soon_threadsafe` schedules the put on the event loop from any thread.
+
+### `agentflow/core/state/__init__.py`
+
+Export `StreamEmitter`.
+
+### `agentflow/core/graph/tool_node/constants.py`
+
+Add `"emit"` to injectable parameters so it is excluded from generated LLM tool schemas.
+
+### `agentflow/core/graph/tool_node/base.py`
+
+Extend `ToolNode.stream(...)` to accept:
+
+```python
+emit: StreamEmitter | None = None
+```
+
+Place `emit` **before** the DI-injected `callback_manager` parameter, since parameters with defaults must not follow DI-sentinel parameters in a way that breaks call sites:
+
+```python
+async def stream(
+    self,
+    name: str,
+    args: dict,
+    tool_call_id: str,
+    config: dict,
+    state: AgentState,
+    emit: StreamEmitter | None = None,          # ← before DI param
+    callback_manager: CallbackManager = Inject[CallbackManager],
+) -> AsyncIterator[...]:
+```
+
+Pass `emit` into `_internal_execute(...)` only for the `_funcs` branch. Do not change `ToolNode.invoke(...)` behavior.
+
+### `agentflow/core/graph/tool_node/executors.py`
+
+Update `_internal_execute(...)` to accept:
+
+```python
+emit: StreamEmitter | None = None
+```
+
+Add it to the injectable defaults dict passed to `_prepare_input_data_tool`:
+
+```python
+{
+    "tool_call_id": tool_call_id,
+    "state": state,
+    "config": config,
+    "emit": emit,
+}
+```
+
+Update `_prepare_input_data_tool(...)` so `"emit"` is handled alongside `"state"`, `"config"`, and `"tool_call_id"` in the explicit injection check:
+
+```python
+if param_name in ["state", "config", "tool_call_id", "emit"]:
+    input_data[param_name] = default_data[param_name]
+    continue
+```
+
+**Important:** `"emit"` must appear in this explicit check, not only in `INJECTABLE_PARAMS`. The `INJECTABLE_PARAMS` set causes params to be skipped entirely (using their default value). The explicit check injects the actual value from `default_data`. Adding `"emit"` only to `INJECTABLE_PARAMS` would mean the tool always receives `None` even in streaming mode.
+
+**Note:** `emit` injection applies only to local (`_funcs`) tools. MCP, Composio, and LangChain tool paths are out of scope and are unchanged.
+
+### `agentflow/core/graph/utils/stream_node_handler.py`
+
+Create the emitter in `_handle_single_tool(...)` and pass it to `ToolNode.stream(...)`.
+
+The current parallel tool implementation uses `asyncio.gather(...)`, which collects results before yielding them. To support live emitted chunks, replace that buffering behavior with an output queue pattern so chunks can be yielded as soon as tools emit them.
+
+## Queue Pattern
+
+For each tool call:
+
+1. Create a per-tool `asyncio.Queue()`.
+2. Create a `StreamEmitter` bound to that queue.
+3. Run `ToolNode.stream(...)` in a background `asyncio.Task`.
+4. The emitter pushes `StreamChunk`s into the queue via `loop.call_soon_threadsafe`.
+5. The background task also pushes final tool results into the queue.
+6. When the background task completes, it pushes a sentinel value (`_DONE`) into the queue.
+7. `_handle_single_tool(...)` yields queue items until it sees the sentinel, then stops.
+
+For multiple parallel tool calls:
+
+1. Each tool has its own emitter and its own per-tool queue.
+2. `_call_tools(...)` uses a single shared output queue and `N` background workers.
+3. Each worker drains its tool's generator and pushes results to the shared queue.
+4. Each worker pushes a sentinel when done.
+5. `_call_tools(...)` yields from the shared queue until all `N` sentinels are received.
+
+This replaces the current `asyncio.gather` + full-buffer pattern, allowing chunks from one tool to be yielded immediately without waiting for all other tools to finish.
+
+**Exception safety:** Each background task must push the sentinel in a `finally` block so that an exception inside a tool does not leave the consumer loop hanging forever. The exception should be re-raised after the consumer has finished draining.
+
+## Publisher Integration
+
+Publisher integration is **out of scope for the initial implementation**.
+
+The primary contract for `StreamEmitter` is the graph stream (the `asyncio.Queue` path). Frontend delivery must work without Redis, Kafka, RabbitMQ, or any other backend publisher.
+
+In a future iteration, `StreamEmitter` may optionally mirror emitted chunks to `publish_event(...)` for backend monitoring. The interface should be designed so this can be added without breaking existing users.
+
+## Example Frontend Stream Events
+
+Progress:
+
+```json
+{
+  "event": "updates",
+  "data": {
+    "status": "tool_progress",
+    "message": "Attempt 1 failed. Retrying...",
+    "tool_name": "get_weather",
+    "tool_call_id": "call_abc",
+    "attempt": 1,
+    "max_attempts": 3
+  }
+}
+```
+
+Error:
+
+```json
+{
+  "event": "error",
+  "data": {
+    "status": "tool_failed",
+    "message": "Weather lookup failed after 3 attempts.",
+    "tool_name": "get_weather",
+    "tool_call_id": "call_abc"
+  }
+}
+```
+
+## Acceptance Criteria
+
+1. A streaming tool can receive an injected `emit` parameter.
+2. Calling `emit.progress(...)` inside the tool produces a `StreamChunk` in `app.stream(...)`.
+3. Calling `emit.error(...)` inside the tool produces an error chunk in `app.stream(...)`.
+4. Final tool results still behave as they do today.
+5. `invoke(...)` and `ainvoke(...)` behavior remains unchanged.
+6. `emit` does not appear in generated tool schemas.
+7. Parallel tool calls can emit updates without waiting for all tools to finish.
+8. Existing publisher behavior continues to work.
+
+## Testing Plan
+
+Add tests for:
+
+1. Tool schema generation excludes `emit`.
+2. `app.stream(...)` receives emitted progress chunks from a tool.
+3. `app.stream(...)` receives emitted error chunks from a tool.
+4. `app.invoke(...)` still works without requiring `emit`.
+5. Multiple parallel tools can emit chunks and final results.
+6. Existing tool result messages still merge into state correctly.
+

--- a/examples/react/react_sync.py
+++ b/examples/react/react_sync.py
@@ -1,3 +1,5 @@
+import random
+
 from dotenv import load_dotenv
 
 from agentflow.core import Agent, StateGraph, ToolNode
@@ -13,6 +15,13 @@ checkpointer = InMemoryCheckpointer()
 
 class CustomAgentState(AgentState):
     jd_name: str = "CustomAgentState"
+
+
+def call_weather_api(location: str) -> str:
+    is_failed = random.choice([True, False])  # Randomly simulate success or failure
+    if is_failed:
+        raise Exception("Failed to fetch weather data due to a simulated API error.")
+    return f"The weather in {location} is sunny"
 
 
 def get_weather(
@@ -31,7 +40,20 @@ def get_weather(
         print(f"Number of messages in context: {len(state.context)}")  # type: ignore
 
     # return f"The weather in {location} is sunny"
-    raise Exception("Simulated tool failure for testing error handling.")
+
+    result = ""
+    for i in range(3):  # Try up to 3 times
+        try:
+            result = call_weather_api(location)
+            break  # If successful, exit the loop
+        except Exception as e:
+            print(f"Attempt {i + 1} failed: {e}")
+            if i == 2:  # If it's the last attempt, return an error message
+                result = (
+                    f"Sorry, I couldn't fetch the weather for {location} after multiple attempts."
+                )
+
+    return result
 
 
 # def update_context(

--- a/examples/react_stream/stream_sync.py
+++ b/examples/react_stream/stream_sync.py
@@ -1,7 +1,10 @@
+import time
+
 from dotenv import load_dotenv
 
 from agentflow.core import Agent, StateGraph, ToolNode
 from agentflow.core.state import AgentState, Message
+from agentflow.core.state.stream_emitter import StreamEmitter
 from agentflow.storage.checkpointer import InMemoryCheckpointer
 from agentflow.utils.constants import END
 
@@ -20,16 +23,29 @@ def get_weather(
     location: str,
     tool_call_id: str | None = None,
     state: AgentState | None = None,
+    emit: StreamEmitter | None = None,
 ) -> str:
     """
     Get the current weather for a specific location.
     This demo shows injectable parameters: tool_call_id and state are automatically injected.
     """
     # You can access injected parameters here
+
+    if emit:
+        emit.progress("Fetching weather data...", data={"location": location})
+
+    time.sleep(1)  # Simulate a delay in fetching weather data
+
+    if emit:
+        emit.progress("Processing weather data...", data={"location": location})
+
     if tool_call_id:
         print(f"Tool call ID: {tool_call_id}")
     if state and hasattr(state, "context"):
         print(f"Number of messages in context: {len(state.context)}")  # type: ignore
+
+    if emit:
+        emit.progress("Finalizing response...", data={"location": location})
 
     return f"The weather in {location} is sunny"
 
@@ -44,13 +60,14 @@ main_agent = Agent(
         {
             "role": "system",
             "content": """
-                You are a helpful assistant.
-                Your task is to assist the user in finding information and answering questions.
+                You are a helpful assistant with access to a get_weather tool.
+                When asked about weather for any location you MUST call the get_weather tool.
+                Do not answer weather questions from your own knowledge.
             """,
         },
         {"role": "user", "content": "Today Date is 2024-06-15"},
     ],
-    tools=tool_node,
+    tool_node=tool_node,
     trim_context=True,
 )
 
@@ -101,7 +118,7 @@ app = graph.compile(
 
 
 # now run it
-inp = {"messages": [Message.text_message("HI")]}
+inp = {"messages": [Message.text_message("Please call the get_weather function for Paris")]}
 config = {"thread_id": "12345", "recursion_limit": 10, "is_stream": True}
 
 res = app.stream(inp, config=config)

--- a/tests/graph/test_parallel_tool_calls.py
+++ b/tests/graph/test_parallel_tool_calls.py
@@ -846,10 +846,13 @@ class TestStreamToolOrderPreserved:
             if isinstance(chunk, Message):
                 results.append(chunk)
 
-        # Verify results are in the same order as calls (not completion order)
+        # Verify we got all results
         assert len(results) == 3
         result_values = [r.content[0].output["value"] for r in results]
-        assert result_values == [1, 2, 3]  # Order preserved
+        # With the queue-based streaming approach, results arrive in completion
+        # order (fastest tool first), not in call order.  The slowest tool
+        # (delay=0.3, value=1) finishes last so value 1 appears at the end.
+        assert sorted(result_values) == [1, 2, 3]  # All results present
 
         # Verify execution order was different (completed in reverse)
         assert execution_order == [3, 2, 1]  # Fastest first


### PR DESCRIPTION
This pull request introduces the new `StreamEmitter` utility and integrates it throughout the tool execution pipeline to enable tools to emit live progress and status updates during streaming execution. This enhancement provides a more responsive and informative streaming experience for users, especially in the frontend, by allowing tools to send incremental updates, progress, and errors as they run. The changes include updates to function signatures, parameter passing, and queue-based streaming logic to support this feature.

**Major feature: Live streaming updates via StreamEmitter**

*Introduction of StreamEmitter:*
- Added the new `StreamEmitter` class in `agentflow/core/state/stream_emitter.py`, which allows tool functions to emit live progress, message, and error updates as `StreamChunk` objects during streaming execution. The emitter is thread-safe and designed for use in both async and sync tool contexts.

*Integration into tool execution pipeline:*
- Updated `stream` and `_internal_execute` methods in `agentflow/core/graph/tool_node/base.py` and `agentflow/core/graph/tool_node/executors.py` to accept and forward an optional `emit: StreamEmitter` parameter, ensuring that tools can receive the emitter when streaming. [[1]](diffhunk://#diff-47012dd8fa749c35dfa82bdc9838d5c8473439811c2e86d3d4bc6f82e2b46d61R497) [[2]](diffhunk://#diff-47012dd8fa749c35dfa82bdc9838d5c8473439811c2e86d3d4bc6f82e2b46d61R634) [[3]](diffhunk://#diff-15a46a023df09b5eb666b897fe837273c0edf8308ad9d60cc0250543756cb93fR524) [[4]](diffhunk://#diff-15a46a023df09b5eb666b897fe837273c0edf8308ad9d60cc0250543756cb93fR546)
- Modified the injectable parameters list in `agentflow/core/graph/tool_node/constants.py` to include `"emit"`, enabling dependency injection of the emitter into tool functions.
- Added a sentinel import and type hint for `StreamEmitter` in `executors.py` to avoid circular dependencies.

**Streaming handler enhancements:**

- Refactored the tool streaming logic in `agentflow/core/graph/utils/stream_node_handler.py` to instantiate a per-tool `StreamEmitter`, queue, and background task for each tool call. This allows tools to push updates into the queue, which are then yielded to the frontend as soon as they are available. [[1]](diffhunk://#diff-2f5e20265e0ed22e55f725c2130f8bb73cb0d867430763d05cc3b3d9a5c957f3L114-R167) [[2]](diffhunk://#diff-2f5e20265e0ed22e55f725c2130f8bb73cb0d867430763d05cc3b3d9a5c957f3L157-R196) [[3]](diffhunk://#diff-2f5e20265e0ed22e55f725c2130f8bb73cb0d867430763d05cc3b3d9a5c957f3L185-R207) [[4]](diffhunk://#diff-2f5e20265e0ed22e55f725c2130f8bb73cb0d867430763d05cc3b3d9a5c957f3L197-R220)
- Improved parallel tool execution by using a shared output queue and per-worker sentinels, so results from multiple tools are streamed to the frontend as soon as they are available, not after all complete.

**API and import updates:**

- Exported `StreamEmitter` from `agentflow/core/state/__init__.py` for convenient import throughout the codebase. [[1]](diffhunk://#diff-2e3404ad0021e70d98d93d1257fe333381b405bb71aba7f05dff7e4b13bd03f6R41) [[2]](diffhunk://#diff-2e3404ad0021e70d98d93d1257fe333381b405bb71aba7f05dff7e4b13bd03f6R63)

**Internal logic improvements:**

- Simplified parameter handling in `_prepare_input_data_tool` to use the new `default_data` dictionary for all injectable parameters, including `emit`.

These changes collectively enable tools to provide real-time feedback during execution, improving observability and user experience in streaming scenarios.