### PR TITLE
feat: enhance error handling in tool execution and update ToolResult to include is_error flag

### DIFF
--- a/agentflow/core/graph/tool_node/executors.py
+++ b/agentflow/core/graph/tool_node/executors.py
@@ -31,6 +31,57 @@ if t.TYPE_CHECKING:
 
 logger = logging.getLogger("agentflow.graph.tool_node")
 
+_STATUS_OK: set[str] = {"completed", "success", "ok", "done", "true", "1"}
+_STATUS_FAIL: set[str] = {"failed", "failure", "error", "false", "0"}
+_ERROR_TRUE: set[str] = {"true", "1", "yes", "error", "failed", "failure"}
+
+
+def _safe_serialize(obj: t.Any) -> dict[str, t.Any]:
+    try:
+        json.dumps(obj)
+        return obj if isinstance(obj, dict) else {"content": obj}
+    except (TypeError, OverflowError):
+        if hasattr(obj, "model_dump"):
+            dumped = obj.model_dump()  # type: ignore
+            if isinstance(dumped, dict) and dumped.get("type") == "resource":
+                resource = dumped.get("resource", {})
+                if isinstance(resource, dict) and "uri" in resource:
+                    resource["uri"] = str(resource["uri"])
+                    dumped["resource"] = resource
+            return dumped
+        return {"content": str(obj), "type": "fallback"}
+
+
+def _as_bool(val: t.Any, truthy_set: set[str]) -> bool:
+    if isinstance(val, bool):
+        return val
+    return str(val).lower() in truthy_set
+
+
+def _extract_block_meta(
+    data: dict[str, t.Any],
+) -> tuple[bool, dict[str, t.Any]]:
+    """Normalize arbitrary status/error keys; return (is_error, cleaned_data)."""
+    data = dict(data)
+
+    raw_status = data.pop("status", None)
+    raw_is_error = data.pop("is_error", data.pop("error", None))
+    raw_success = data.pop("success", None)
+
+    if raw_is_error is not None:
+        is_error = _as_bool(raw_is_error, _ERROR_TRUE)
+    elif raw_success is not None:
+        is_error = not _as_bool(raw_success, _STATUS_OK)
+    else:
+        is_error = False
+
+    if raw_status is not None:
+        s = str(raw_status).lower()
+        if s in _STATUS_FAIL:
+            is_error = True
+
+    return is_error, data
+
 
 class ComposioMixin:
     _composio: ComposioAdapter | None
@@ -439,31 +490,25 @@ class LocalExecMixin:
         result: t.Any,
         tool_call_id: str,
     ) -> list[ContentBlock]:
-        def safe_serialize(obj: t.Any) -> dict[str, t.Any]:
-            try:
-                json.dumps(obj)
-                return obj if isinstance(obj, dict) else {"content": obj}
-            except (TypeError, OverflowError):
-                if hasattr(obj, "model_dump"):
-                    dumped = obj.model_dump()  # type: ignore
-                    if isinstance(dumped, dict) and dumped.get("type") == "resource":
-                        resource = dumped.get("resource", {})
-                        if isinstance(resource, dict) and "uri" in resource:
-                            resource["uri"] = str(resource["uri"])
-                            dumped["resource"] = resource
-                    return dumped
-                return {"content": str(obj), "type": "fallback"}
+        is_error = False
 
         if isinstance(result, str):
             output: str | list[dict[str, t.Any]] = result
         elif isinstance(result, dict):
-            output = [safe_serialize(result)]
+            is_error, cleaned = _extract_block_meta(result)
+            output = [_safe_serialize(cleaned)]
         elif hasattr(result, "model_dump"):
-            output = [safe_serialize(result.model_dump())]
+            dumped = result.model_dump()  # type: ignore
+            if isinstance(dumped, dict):
+                is_error, cleaned = _extract_block_meta(dumped)
+                output = [_safe_serialize(cleaned)]
+            else:
+                output = [_safe_serialize(dumped)]
         elif hasattr(result, "__dict__"):
-            output = [safe_serialize(result.__dict__)]
+            is_error, cleaned = _extract_block_meta(result.__dict__)
+            output = [_safe_serialize(cleaned)]
         elif isinstance(result, list):
-            output = [safe_serialize(item) for item in result]
+            output = [_safe_serialize(item) for item in result]
         else:
             output = str(result)
 
@@ -471,8 +516,8 @@ class LocalExecMixin:
             ToolResultBlock(
                 call_id=tool_call_id,
                 output=output,
-                status="completed",
-                is_error=False,
+                status="failed" if is_error else "completed",
+                is_error=is_error,
             )
         ]
 
@@ -496,8 +541,8 @@ class LocalExecMixin:
                         ToolResultBlock(
                             call_id=tool_call_id,
                             output=result.message,
-                            status="completed",
-                            is_error=False,
+                            status="failed" if result.is_error else "completed",
+                            is_error=result.is_error,
                         )
                     ],
                     meta=meta,

--- a/agentflow/core/state/tool_result.py
+++ b/agentflow/core/state/tool_result.py
@@ -17,6 +17,7 @@ class ToolResult:
         message: The text response to return to the AI (used as the tool result content).
         state: Optional dict mapping state field names to their new values.
             Only fields present in the dict are updated; other fields are left unchanged.
+        is_error: If True, the result is marked as a failed tool call (status="failed").
 
     Example::
 
@@ -33,3 +34,4 @@ class ToolResult:
 
     message: Any
     state: dict[str, Any] | None = field(default=None)
+    is_error: bool = field(default=False)


### PR DESCRIPTION
This pull request improves how tool execution results are handled and serialized in the agent framework, making error detection more robust and consistent. The main changes include introducing utility functions for normalizing and serializing tool results, updating the result block construction to better reflect error states, and adding an `is_error` field to the `ToolResult` data structure.

**Error normalization and serialization improvements:**

* Added utility functions (`_safe_serialize`, `_extract_block_meta`, `_as_bool`) to standardize how tool results are serialized and how error/status fields are interpreted, ensuring consistent output and error detection across different result types.
* Updated the internal result block construction logic to use these utilities, so that error states are accurately reflected in the `status` and `is_error` fields of `ToolResultBlock`.
* Adjusted message construction from internal results to set the correct error status and flag based on the new logic.

**Data structure changes:**

* Added an `is_error` field to the `ToolResult` dataclass, allowing tool results to explicitly indicate failure states.
* Updated documentation for `ToolResult` to describe the new `is_error` field.