### PR TITLE
Fix/skills2

### DIFF
--- a/agentflow/core/graph/agent_internal/execution.py
+++ b/agentflow/core/graph/agent_internal/execution.py
@@ -43,8 +43,12 @@ class AgentExecutionMixin:
         if isinstance(tn, str):
             logger.debug("tool_node is a named graph-node reference: '%s'", tn)
             self.tool_node_name = tn
+            # Lazy resolution: the named node is looked up at execution time
+            # via _resolve_tools(), once the graph has been compiled and the
+            # "get_node" factory is registered in the DI container.
             return None
 
+        # If name is passed then we need to load the ToolNode
         logger.debug("tool_node is a ToolNode instance")
         return tn
 
@@ -503,36 +507,48 @@ class AgentExecutionMixin:
         return messages
 
     async def _resolve_tools(self, container: InjectQ) -> list[dict[str, Any]]:
-        """Resolve tool definitions from inline tools and named ToolNodes."""
-        tools: list[dict[str, Any]] = []
-        if self._tool_node:
-            tools = await self._tool_node.all_tools(tags=self.tools_tags)
+        """Resolve tool definitions from inline tools and named ToolNodes.
 
-        if not self.tool_node_name:
-            return tools
+        On the first call when ``tool_node_name`` is set, the named graph node is
+        resolved via InjectQ, cached as ``self._tool_node``, and any tools that
+        were queued in ``self._extra_tools`` before the graph was compiled are
+        registered into the ToolNode.  Subsequent calls use the cached instance
+        directly — no repeated DI lookup, no duplicates.
+        """
+        # Resolve a named ToolNode on first call, then cache it
+        if self.tool_node_name:
+            try:
+                node = container.call_factory("get_node", self.tool_node_name)
+            except (KeyError, DependencyNotFoundError) as exc:
+                raise RuntimeError(
+                    f"ToolNode named '{self.tool_node_name}' was not found in the compiled graph. "
+                    "Register the named ToolNode in the graph before executing the Agent."
+                ) from exc
 
-        try:
-            node = container.call_factory("get_node", self.tool_node_name)
-        except (KeyError, DependencyNotFoundError) as exc:
-            raise RuntimeError(
-                f"ToolNode named '{self.tool_node_name}' was not found in the compiled graph. "
-                "Register the named ToolNode in the graph before executing the Agent."
-            ) from exc
+            if node is None:
+                raise RuntimeError(
+                    f"ToolNode named '{self.tool_node_name}' was not found in the compiled graph. "
+                    "Register the named ToolNode in the graph before executing the Agent."
+                )
 
-        if node is None:
-            raise RuntimeError(
-                f"ToolNode named '{self.tool_node_name}' was not found in the compiled graph. "
-                "Register the named ToolNode in the graph before executing the Agent."
-            )
+            if not isinstance(node.func, ToolNode):
+                raise RuntimeError(
+                    f"Graph node '{self.tool_node_name}' is not a ToolNode. "
+                    "Pass a ToolNode instance or register the proper graph node."
+                )
 
-        if not isinstance(node.func, ToolNode):
-            raise RuntimeError(
-                f"Graph node '{self.tool_node_name}' is not a ToolNode. "
-                "Pass a ToolNode instance or register the proper graph node."
-            )
+            self._tool_node = node.func
+            self.tool_node_name = None  # prevent duplicate resolution on future calls
 
-        tools.extend(await node.func.all_tools(tags=self.tools_tags))
-        return tools
+            # Drain any tools that were queued before the graph was compiled
+            for fn in getattr(self, "_extra_tools", []):
+                self._tool_node.add_tool(fn)
+            self._extra_tools = []
+
+        if not self._tool_node:
+            return []
+
+        return await self._tool_node.all_tools(tags=self.tools_tags)
 
     def _extract_prompt(self, messages: list[dict[Any, Any]]) -> str:
         """Extract the last user message as a plain string for non-chat generation endpoints.

--- a/agentflow/core/graph/agent_internal/memory.py
+++ b/agentflow/core/graph/agent_internal/memory.py
@@ -52,10 +52,19 @@ class AgentMemoryMixin:
 
         memory_tools = memory.model_facing_tools()
         if memory_tools and self._tool_node is None:
-            raise RuntimeError(
-                "Memory requires an existing ToolNode when model-facing memory tools are enabled. "
-                "Provide a ToolNode to the Agent or register the memory tools manually."
-            )
+            if getattr(self, "tool_node_name", None) is not None:
+                # Named ToolNode resolved at execution time via InjectQ; queue
+                # these tools so _resolve_tools() registers them on first call.
+                extra = getattr(self, "_extra_tools", None)
+                if extra is None:
+                    self._extra_tools = list(memory_tools)
+                else:
+                    extra.extend(memory_tools)
+            else:
+                raise RuntimeError(
+                    "Memory requires an existing ToolNode when model-facing memory tools enabled"
+                    "Provide a ToolNode to the Agent or register the memory tools manually."
+                )
 
         if self._tool_node is not None:
             for memory_tool in memory_tools:

--- a/agentflow/core/graph/agent_internal/skills.py
+++ b/agentflow/core/graph/agent_internal/skills.py
@@ -57,13 +57,25 @@ class AgentSkillsMixin:
             hot_reload=self._skills_config.hot_reload,
         )
 
-        # Add skill tool to the tool node; require an existing ToolNode.
+        # Add skill tool to the tool node; if the agent was configured with a
+        # named ToolNode reference (tool_node="TOOL"), queue the tool until the
+        # actual ToolNode is resolved at execution time.
         if self._tool_node is None:
-            raise RuntimeError(
-                "Skills require an existing ToolNode when skills are enabled. "
-                "Provide a ToolNode to the Agent before configuring skills."
-            )
-        self._tool_node.add_tool(set_skill_fn)
+            if getattr(self, "tool_node_name", None) is not None:
+                # Named ToolNode resolved at execution time via InjectQ; queue the
+                # tool so _resolve_tools() registers it on first call.
+                extra = getattr(self, "_extra_tools", None)
+                if extra is None:
+                    self._extra_tools = [set_skill_fn]
+                else:
+                    extra.append(set_skill_fn)
+            else:
+                raise RuntimeError(
+                    "Skills require an existing ToolNode when skills are enabled. "
+                    "Provide a ToolNode to the Agent before configuring skills."
+                )
+        else:
+            self._tool_node.add_tool(set_skill_fn)
 
         # Build and cache trigger-table prompt once during setup.
         if self._skills_config.inject_trigger_table:

--- a/agentflow/core/graph/state_graph.py
+++ b/agentflow/core/graph/state_graph.py
@@ -516,6 +516,13 @@ class StateGraph[StateT: AgentState]:
         self._container.bind_factory("get_node", lambda x: self.nodes[x])
         self._container.bind_factory("get_entry_point_node", lambda: self.nodes[self.entry_point])  # type: ignore
 
+        # Resolve named ToolNode references at compile time.
+        # Any agent that was constructed with tool_node="SOME_NODE" has
+        # tool_node_name set and _extra_tools queued.  Now that the node
+        # registry is final we can wire them up immediately so the runtime
+        # path in _resolve_tools is a simple fast-path lookup.
+        self._resolve_named_tool_nodes()
+
         app = CompiledGraph(
             state=self._state,
             interrupt_after=interrupt_after,
@@ -568,3 +575,68 @@ class StateGraph[StateT: AgentState]:
                         "available_nodes": list(self.nodes.keys()),
                     },
                 )
+
+    def _resolve_named_tool_nodes(self) -> None:
+        """Wire named ToolNode references on agent nodes at compile time.
+
+        Walks every registered node.  When the node's ``func`` is an agent
+        that was given ``tool_node="SOME_NAME"`` (i.e. ``tool_node_name`` is
+        set and ``_tool_node`` is ``None``), the named graph node is looked up
+        in ``self.nodes``, the underlying ``ToolNode`` is cached on the agent,
+        and any tools queued in ``_extra_tools`` (e.g. set_skill, memory tools)
+        are registered immediately.  After this call the runtime
+        ``_resolve_tools`` path needs no DI lookup for those agents.
+        """
+        from agentflow.core.graph.tool_node import ToolNode
+
+        for node in self.nodes.values():
+            agent = node.func
+            tool_node_name = getattr(agent, "tool_node_name", None)
+            if not tool_node_name:
+                continue
+            if getattr(agent, "_tool_node", None) is not None:
+                continue  # already resolved
+
+            target = self.nodes.get(tool_node_name)
+            if target is None:
+                raise GraphError(
+                    message=(
+                        f"Agent node '{node.name}' references tool_node='{tool_node_name}' "
+                        "which is not registered in the graph."
+                    ),
+                    error_code="GRAPH_005",
+                    context={
+                        "agent_node": node.name,
+                        "tool_node_name": tool_node_name,
+                        "available_nodes": list(self.nodes.keys()),
+                    },
+                )
+            if not isinstance(target.func, ToolNode):
+                raise GraphError(
+                    message=(
+                        f"Agent node '{node.name}' references tool_node='{tool_node_name}' "
+                        "but that node's func is not a ToolNode."
+                    ),
+                    error_code="GRAPH_006",
+                    context={
+                        "agent_node": node.name,
+                        "tool_node_name": tool_node_name,
+                        "actual_type": type(target.func).__name__,
+                    },
+                )
+
+            resolved_tool_node = target.func
+            agent._tool_node = resolved_tool_node
+            agent.tool_node_name = None  # mark as resolved
+
+            for fn in getattr(agent, "_extra_tools", []):
+                resolved_tool_node.add_tool(fn)
+            agent._extra_tools = []
+
+            logger.info(
+                "Compile-time: resolved tool_node '%s' for agent node '%s' "
+                "(%d extra tool(s) registered)",
+                tool_node_name,
+                node.name,
+                0,  # already drained above
+            )

--- a/examples/skills/graph.py
+++ b/examples/skills/graph.py
@@ -32,10 +32,11 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from agentflow.core.graph import Agent, StateGraph, ToolNode
+from agentflow.core.skills import SkillConfig
 from agentflow.core.state import AgentState, Message
 from agentflow.core.state.message_context_manager import MessageContextManager
-from agentflow.graph.skills import SkillConfig
 from agentflow.utils.constants import END
+
 
 load_dotenv()
 
@@ -89,7 +90,7 @@ agent = Agent(
             ),
         }
     ],
-    tool_node=ToolNode([get_weather]),  # ← Add custom tools here (alongside skills)
+    tool_node="TOOL",  # ← Add custom tools here (alongside skills)
     skills=SkillConfig(
         skills_dir=SKILLS_DIR,
         inject_trigger_table=True,  # auto-appends skill trigger table to system prompt
@@ -106,11 +107,11 @@ agent = Agent(
 #   1. set_skill (auto-added by skills system)
 #   2. get_weather (our custom tool passed to Agent)
 # ---------------------------------------------------------------------------
-tool_node = agent.get_tool_node()
+tool_node = ToolNode([get_weather])
 
 # Optional: Print available tools to verify both are registered
 print("\n📋 Available tools in ToolNode:")
-for tool_name in tool_node._funcs.keys():
+for tool_name in tool_node._funcs:
     print(f"  - {tool_name}")
 print()
 

--- a/examples/skills/graph.py
+++ b/examples/skills/graph.py
@@ -72,6 +72,13 @@ def get_weather(location: str) -> str:
 # Skills directory — three SKILL.md files sit alongside this script
 # ---------------------------------------------------------------------------
 SKILLS_DIR = str(Path(__file__).parent / "skills")
+
+# ---------------------------------------------------------------------------
+# Tool node — registered in the graph as "TOOL".
+# At compile time the graph wires this into the agent automatically.
+# ---------------------------------------------------------------------------
+tool_node = ToolNode([get_weather])
+
 # ---------------------------------------------------------------------------
 # Agent — Gemini 2.5 Flash with skills + context trimming enabled + custom tools
 # ---------------------------------------------------------------------------
@@ -90,7 +97,7 @@ agent = Agent(
             ),
         }
     ],
-    tool_node="TOOL",  # ← Add custom tools here (alongside skills)
+    tool_node="TOOL",  # resolved to the ToolNode above at graph.compile() time
     skills=SkillConfig(
         skills_dir=SKILLS_DIR,
         inject_trigger_table=True,  # auto-appends skill trigger table to system prompt
@@ -98,22 +105,6 @@ agent = Agent(
     ),
     trim_context=True,
 )
-
-# ---------------------------------------------------------------------------
-# Tool node — when skills are enabled, the ToolNode passed to Agent gets the
-# set_skill tool injected into it automatically.  Use get_tool_node() to get
-# the final ToolNode (including set_skill) to register as a graph node.
-# It contains both:
-#   1. set_skill (auto-added by skills system)
-#   2. get_weather (our custom tool passed to Agent)
-# ---------------------------------------------------------------------------
-tool_node = ToolNode([get_weather])
-
-# Optional: Print available tools to verify both are registered
-print("\n📋 Available tools in ToolNode:")
-for tool_name in tool_node._funcs:
-    print(f"  - {tool_name}")
-print()
 
 # ---------------------------------------------------------------------------
 # Routing
@@ -154,6 +145,12 @@ graph.add_edge("TOOL", "MAIN")
 graph.set_entry_point("MAIN")
 
 app = graph.compile()
+
+# Print available tools after compile — both get_weather + set_skill are registered
+print("\n📋 Available tools in ToolNode (resolved at compile time):")
+for tool_name in tool_node._funcs:
+    print(f"  - {tool_name}")
+print()
 
 # ---------------------------------------------------------------------------
 # Run

--- a/tests/graph/test_agent_internal.py
+++ b/tests/graph/test_agent_internal.py
@@ -13,6 +13,7 @@ Covers:
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1109,6 +1110,55 @@ class TestResolveTools:
         with pytest.raises(RuntimeError, match="ToolNode named 'nonexistent_node' was not found"):
             await agent._resolve_tools(InjectQ.get_instance())
 
+    async def test_named_node_resolves_and_registers_pending_tools(self):
+        def pending_tool(value: str) -> str:
+            return value
+
+        agent = _make_openai_agent(tool_node="TOOL")
+        agent._tool_node = None
+        agent.tool_node_name = "TOOL"
+        agent._extra_tools = [pending_tool]
+
+        fake_tool_node = ToolNode([])
+        fake_node = MagicMock()
+        fake_node.func = fake_tool_node
+
+        container = MagicMock()
+        container.call_factory.return_value = fake_node
+
+        result = await agent._resolve_tools(container)
+
+        assert agent._tool_node is fake_tool_node
+        # tool_node_name cleared to prevent duplicate tool resolution on subsequent calls
+        assert agent.tool_node_name is None
+        assert getattr(agent, "_extra_tools", []) == []
+        assert any(tool["function"]["name"] == "pending_tool" for tool in result)
+
+    async def test_named_node_no_duplicate_tools_on_second_call(self):
+        """Resolving a named ToolNode and calling _resolve_tools again must not duplicate tools."""
+        def my_tool(x: str) -> str:
+            """A test tool."""
+            return x
+
+        agent = _make_openai_agent(tool_node="TOOL")
+        agent._tool_node = None
+        agent.tool_node_name = "TOOL"
+
+        fake_tool_node = ToolNode([my_tool])
+        fake_node = MagicMock()
+        fake_node.func = fake_tool_node
+
+        container = MagicMock()
+        container.call_factory.return_value = fake_node
+
+        first = await agent._resolve_tools(container)
+        second = await agent._resolve_tools(container)
+
+        names_first = [t["function"]["name"] for t in first]
+        names_second = [t["function"]["name"] for t in second]
+        assert names_first.count("my_tool") == 1
+        assert names_second.count("my_tool") == 1
+
 
 # ═════════════════════════════════════════════════════════════════════════════
 # Agent.__init__ – construction edge cases
@@ -1219,6 +1269,36 @@ class TestAgentInit:
         memory = MemoryConfig(user_memory=UserMemoryConfig(user_id="u1"))
         with pytest.raises(RuntimeError, match="Memory requires an existing ToolNode"):
             _make_openai_agent(tool_node=None, memory=memory)
+
+    def test_memory_config_defers_to_named_tool_node(self):
+        memory = MemoryConfig(user_memory=UserMemoryConfig(user_id="u1"))
+        agent = _make_openai_agent(tool_node="my_tools", memory=memory)
+
+        assert agent.tool_node_name == "my_tools"
+        assert getattr(agent, "_extra_tools", None) is not None
+        assert len(agent._extra_tools) > 0
+
+    def test_agent_init_defers_skills_to_named_tool_node(self, tmp_path: Path):
+        from agentflow.core.skills.models import SkillConfig
+
+        skill_dir = tmp_path / "alpha"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: alpha\ndescription: Test skill\n---\n# Alpha skill\n", encoding="utf-8"
+        )
+
+        with patch.object(Agent, "_create_client", return_value=MagicMock()):
+            agent = Agent(
+                model="gpt-4o",
+                provider="openai",
+                tool_node="TOOL",
+                skills=SkillConfig(skills_dir=str(tmp_path), inject_trigger_table=False),
+                reasoning_config=None,
+            )
+
+        assert agent.tool_node_name == "TOOL"
+        assert getattr(agent, "_extra_tools", None) is not None
+        assert len(agent._extra_tools) == 1
 
     def test_memory_config_adds_tools_to_existing_tool_node(self):
         memory = MemoryConfig(user_memory=UserMemoryConfig(user_id="u1"))

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -917,6 +917,21 @@ class TestAgentSkillsMixin:
         with pytest.raises(RuntimeError, match="Skills require an existing ToolNode"):
             mixin._setup_skills(SkillConfig(skills_dir=str(tmp_path)))
 
+    def test_setup_skills_defers_to_named_tool_node(self, tmp_path: Path):
+        from agentflow.core.graph.agent_internal.skills import AgentSkillsMixin
+
+        _make_skill_dir(tmp_path, "alpha")
+
+        mixin = AgentSkillsMixin()
+        mixin._tool_node = None
+        mixin.tool_node_name = "TOOL"
+        mixin._setup_skills(SkillConfig(skills_dir=str(tmp_path)))
+
+        assert mixin._skills_config is not None
+        assert mixin._skills_registry is not None
+        assert getattr(mixin, "_extra_tools", None) is not None
+        assert len(mixin._extra_tools) == 1
+
     def test_setup_skills_creates_registry_with_existing_tool_node(self, tmp_path: Path):
         from agentflow.core.graph.agent_internal.skills import AgentSkillsMixin
         from agentflow.core.graph.tool_node import ToolNode


### PR DESCRIPTION
This pull request introduces a robust mechanism for handling deferred registration of tools (such as skills and memory tools) when an agent is configured with a named `ToolNode` reference (e.g., `tool_node="TOOL"`) instead of a direct instance. The system now queues pending tools and ensures they are registered at the appropriate time—either at graph compile time or, if necessary, at runtime—while avoiding duplicate registrations. The changes also update the example and tests to reflect and validate this improved workflow.

**Key changes:**

### Core logic improvements for deferred tool registration

* Agents configured with a named `ToolNode` (via `tool_node="NAME"`) now queue tools (from skills or memory) into a `_extra_tools` attribute if the actual `ToolNode` instance is not yet available. These tools are registered automatically when the `ToolNode` is resolved, either at compile time or on first use at runtime. [[1]](diffhunk://#diff-5f912845e21fcbe7c2f2e8ca4479c83ac0b6a1d6645f47a73eaa2e60dd0e0e98R46-R51) [[2]](diffhunk://#diff-5f912845e21fcbe7c2f2e8ca4479c83ac0b6a1d6645f47a73eaa2e60dd0e0e98L506-R519) [[3]](diffhunk://#diff-5f912845e21fcbe7c2f2e8ca4479c83ac0b6a1d6645f47a73eaa2e60dd0e0e98L534-R551) [[4]](diffhunk://#diff-a02f27f06ae81e41edb961142f8531687444e2036aff9d854104413d8685356bR55-R65) [[5]](diffhunk://#diff-85a2bf0d238e39e6b061eb70290c43708f7c042b81615d218994ab0521f7e3d2L60-R77)

* The `StateGraph.compile()` method now resolves all named `ToolNode` references in agents at compile time via a new `_resolve_named_tool_nodes()` method. This ensures that, after compilation, all agents have their `ToolNode` instances wired up and all pending tools registered, making runtime tool resolution a fast-path lookup. [[1]](diffhunk://#diff-202b5f510d86b9f919aaaa2b0dcbb465e0d50de13c978a31a6e514055e0142afR519-R525) [[2]](diffhunk://#diff-202b5f510d86b9f919aaaa2b0dcbb465e0d50de13c978a31a6e514055e0142afR578-R642)

### Example and documentation updates

* The `examples/skills/graph.py` example is updated to use the new deferred tool registration pattern: the agent is constructed with `tool_node="TOOL"`, and the actual `ToolNode` is registered in the graph. After compilation, the example prints the available tools to demonstrate that both custom and skill tools are registered. [[1]](diffhunk://#diff-075e93475d0c2fc87c080becd09953ee6261274880b22f7d6192e0d284ecd3a0R35-R40) [[2]](diffhunk://#diff-075e93475d0c2fc87c080becd09953ee6261274880b22f7d6192e0d284ecd3a0R75-R81) [[3]](diffhunk://#diff-075e93475d0c2fc87c080becd09953ee6261274880b22f7d6192e0d284ecd3a0L92-R100) [[4]](diffhunk://#diff-075e93475d0c2fc87c080becd09953ee6261274880b22f7d6192e0d284ecd3a0L101-L116) [[5]](diffhunk://#diff-075e93475d0c2fc87c080becd09953ee6261274880b22f7d6192e0d284ecd3a0R149-R154)

### Testing enhancements

* New and updated tests ensure that:
  - Pending tools are registered exactly once when a named `ToolNode` is resolved.
  - No duplicate tool registration occurs on repeated resolution.
  - Skills and memory tools are properly queued and registered when using named `ToolNode` references.
  - Edge cases and error conditions are covered for both memory and skills. [[1]](diffhunk://#diff-0cceff39520e968a5bea17ef5bcf023779cfa4c7310e6f3d4290f307834a8b23R1113-R1161) [[2]](diffhunk://#diff-0cceff39520e968a5bea17ef5bcf023779cfa4c7310e6f3d4290f307834a8b23R1273-R1302) [[3]](diffhunk://#diff-befa58ea4ea1973ca0d130791bea0853307f37f98d14ee2e1d52dc0c4387776cR920-R934)