### PR TITLE
fix: handle None content gracefully in GoogleGenAIConverter by ensuri…

### DIFF
--- a/agentflow/runtime/adapters/llm/google_genai_converter.py
+++ b/agentflow/runtime/adapters/llm/google_genai_converter.py
@@ -83,7 +83,7 @@ class GoogleGenAIConverter(BaseConverter):
         usages = self._extract_usage_metadata(response)
 
         # Extract parts from content
-        parts = content.parts if content else []
+        parts = (content.parts or []) if content else []
         blocks, tools_calls, reasoning_content = self._process_parts(parts)
 
         # Get model version and other metadata

--- a/tests/adapters/test_google_genai_converter.py
+++ b/tests/adapters/test_google_genai_converter.py
@@ -250,6 +250,22 @@ class TestGoogleGenAIConverter:
         assert message.metadata["provider"] == "google_genai"
 
     @pytest.mark.asyncio
+    async def test_convert_response_with_none_content_parts(self, converter):
+        """Test converting a response whose content parts are explicitly None."""
+        content = MockContent(parts=[])
+        content.parts = None
+        candidate = MockCandidate(content=content)
+        response = MockGenerateContentResponse(candidates=[candidate])
+
+        message = await converter.convert_response(response)
+
+        assert isinstance(message, Message)
+        assert message.role == "assistant"
+        assert message.content == []
+        assert message.tools_calls is None
+        assert message.metadata["provider"] == "google_genai"
+
+    @pytest.mark.asyncio
     async def test_convert_response_with_multiple_parts(self, converter):
         """Test converting a response with multiple parts."""
         # Create mock response with text, thought, and function call


### PR DESCRIPTION
This pull request makes a small change to the handling of content parts in the `convert_response` method of `google_genai_converter.py`. The update ensures that if `content.parts` is `None`, it is safely converted to an empty list, preventing potential errors during processing.…ng parts are always a list