### PR TITLE
feat: add logging warnings for empty responses in converters

### DIFF
--- a/agentflow/runtime/adapters/llm/google_genai_converter.py
+++ b/agentflow/runtime/adapters/llm/google_genai_converter.py
@@ -72,6 +72,7 @@ class GoogleGenAIConverter(BaseConverter):
         # Extract candidates (Google GenAI can return multiple candidates)
         candidates = response.candidates or []
         if not candidates:
+            logger.warning("Google GenAI response has no candidates: %s", response)
             # Return empty message if no candidates
             return self._create_empty_message()
 
@@ -84,6 +85,9 @@ class GoogleGenAIConverter(BaseConverter):
 
         # Extract parts from content
         parts = (content.parts or []) if content else []
+        if parts is None:
+            logger.warning("Google GenAI response content has no parts: %s", response)
+
         blocks, tools_calls, reasoning_content = self._process_parts(parts)
 
         # Get model version and other metadata

--- a/agentflow/runtime/adapters/llm/model_response_converter.py
+++ b/agentflow/runtime/adapters/llm/model_response_converter.py
@@ -74,6 +74,12 @@ class ModelResponseConverter:
             logger.error(f"Unsupported converter: {converter}")
             raise ValueError(f"Unsupported converter: {converter}")
 
+    @staticmethod
+    def _warn_if_empty_response(response: Any, *, context: str) -> None:
+        """Emit a warning when a provider returned no payload to convert."""
+        if response is None:
+            logger.warning("Received empty response while %s", context)
+
     async def invoke(self) -> Message:
         """
         Call the underlying function and convert a non-streaming response to Message.
@@ -94,6 +100,7 @@ class ModelResponseConverter:
         else:
             response = self.response
 
+        self._warn_if_empty_response(response, context="converting a model response")
         logger.debug("Converting response to Message")
         return await self.converter.convert_response(response)  # type: ignore
 
@@ -131,6 +138,7 @@ class ModelResponseConverter:
         else:
             response = self.response
 
+        self._warn_if_empty_response(response, context="starting streaming conversion")
         async for item in self.converter.convert_streaming_response(  # type: ignore
             config,
             node_name=node_name,

--- a/agentflow/runtime/adapters/llm/openai_converter.py
+++ b/agentflow/runtime/adapters/llm/openai_converter.py
@@ -80,6 +80,7 @@ class OpenAIConverter(BaseConverter):
 
         choice = response.choices[0] if response.choices else None
         if not choice:
+            logger.warning("OpenAI response has no choices: %s", response)
             return self._build_empty_response_message(response, usages)
 
         message = choice.message

--- a/agentflow/runtime/adapters/llm/openai_responses_converter.py
+++ b/agentflow/runtime/adapters/llm/openai_responses_converter.py
@@ -108,8 +108,12 @@ class OpenAIResponsesConverter(BaseConverter):
         blocks: list = []
         reasoning_text = ""
         tool_calls_raw: list[dict] = []
+        output_items = getattr(response, "output", [])
 
-        for item in getattr(response, "output", []):
+        if not output_items:
+            logger.warning("OpenAI Responses API response has no output items: %s", response)
+
+        for item in output_items:
             item_type = getattr(item, "type", None)
 
             if item_type == "reasoning":

--- a/tests/adapters/test_google_genai_converter.py
+++ b/tests/adapters/test_google_genai_converter.py
@@ -2,11 +2,15 @@
 
 import json
 from datetime import datetime
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
+
+import logging
 
 import pytest
 
 from agentflow.runtime.adapters.llm.google_genai_converter import GoogleGenAIConverter
+from agentflow.runtime.adapters.llm.openai_converter import OpenAIConverter
+from agentflow.runtime.adapters.llm.openai_responses_converter import OpenAIResponsesConverter
 from agentflow.core.state.message import Message
 from agentflow.core.state.message_block import ReasoningBlock, TextBlock, ToolCallBlock
 
@@ -248,6 +252,42 @@ class TestGoogleGenAIConverter:
         assert message.role == "assistant"
         assert len(message.content) == 0
         assert message.metadata["provider"] == "google_genai"
+
+    @pytest.mark.asyncio
+    async def test_openai_converter_logs_warning_for_missing_choices(self, caplog):
+        """Test OpenAI converter warns when choices are missing."""
+        response = MagicMock()
+        response.id = "resp_123"
+        response.model = "gpt-4o-mini"
+        response.created = 1234567890
+        response.choices = []
+        response.usage = None
+
+        with caplog.at_level(logging.WARNING, logger="agentflow.adapters.openai"):
+            message = await OpenAIConverter().convert_response(response)
+
+        assert isinstance(message, Message)
+        assert message.content == []
+        assert "OpenAI response has no choices" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_openai_responses_converter_logs_warning_for_missing_output(self, caplog):
+        """Test Responses API converter warns when output items are missing."""
+        response = MagicMock()
+        response.id = "resp_456"
+        response.model = "gpt-4.1"
+        response.status = "completed"
+        response.created_at = 1234567890
+        response.output = []
+        response.usage = None
+        response.model_dump.return_value = {}
+
+        with caplog.at_level(logging.WARNING, logger="agentflow.adapters.openai_responses"):
+            message = await OpenAIResponsesConverter().convert_response(response)
+
+        assert isinstance(message, Message)
+        assert message.content == []
+        assert "OpenAI Responses API response has no output items" in caplog.text
 
     @pytest.mark.asyncio
     async def test_convert_response_with_none_content_parts(self, converter):

--- a/tests/test_model_response_converter.py
+++ b/tests/test_model_response_converter.py
@@ -1,9 +1,11 @@
 """Tests for ModelResponseConverter."""
 
-import pytest
 import asyncio
 import inspect
+import logging
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
+
+import pytest
 
 from agentflow.runtime.adapters.llm.model_response_converter import ModelResponseConverter
 from agentflow.runtime.adapters.llm.base_converter import BaseConverter
@@ -69,6 +71,19 @@ class TestModelResponseConverter:
         
         assert result == mock_message
         mock_converter.convert_response.assert_called_once_with("static response")
+
+    @pytest.mark.asyncio
+    async def test_invoke_logs_warning_for_none_response(self, caplog):
+        """Test invoke warns when the wrapped response is empty."""
+        mock_converter = AsyncMock(spec=BaseConverter)
+        mock_converter.convert_response.return_value = Message.text_message("Converted response", "assistant")
+
+        converter = ModelResponseConverter(None, mock_converter)
+
+        with caplog.at_level(logging.WARNING, logger="agentflow.adapters"):
+            await converter.invoke()
+
+        assert "Received empty response while converting a model response" in caplog.text
 
     @pytest.mark.asyncio
     async def test_invoke_with_sync_callable(self):
@@ -184,6 +199,27 @@ class TestModelResponseConverter:
         mock_converter.convert_streaming_response.assert_called_once_with(
             config, node_name=node_name, response="stream response", meta=meta
         )
+
+    @pytest.mark.asyncio
+    async def test_stream_logs_warning_for_none_response(self, caplog):
+        """Test stream warns when the wrapped response is empty."""
+        config = {"thread_id": "test_thread"}
+        node_name = "test_node"
+        mock_converter = AsyncMock(spec=BaseConverter)
+
+        async def mock_stream_generator():
+            yield Message.text_message("Stream chunk", "assistant")
+
+        mock_converter.convert_streaming_response = Mock(return_value=mock_stream_generator())
+        converter = ModelResponseConverter(None, mock_converter)
+
+        with caplog.at_level(logging.WARNING, logger="agentflow.adapters"):
+            results = []
+            async for message in converter.stream(config, node_name):
+                results.append(message)
+
+        assert len(results) == 1
+        assert "Received empty response while starting streaming conversion" in caplog.text
 
     @pytest.mark.asyncio
     async def test_stream_with_sync_callable(self):


### PR DESCRIPTION
This pull request adds improved warning and logging for cases where LLM API responses are empty or missing expected fields, making error diagnosis and debugging easier. It also introduces corresponding tests to ensure that these warnings are emitted as expected.

**Logging improvements for empty or malformed LLM responses:**

* Added warnings in `GoogleGenAIConverter`, `OpenAIConverter`, and `OpenAIResponsesConverter` to log when no candidates, choices, or output items are present in the response. [[1]](diffhunk://#diff-70f45a11f004e3db319bb99420935336e4c0a4e583561241d8ef4a3d994a1e86R75) [[2]](diffhunk://#diff-f1da75d95e676f323301a9a40921c9d5ecf9dfc5cba88a0b6ed72358d76b1b7fR83) [[3]](diffhunk://#diff-3cb509e64d2cb4ae4843008587e312ab5c879d6a2be4b866063f96bd2eb350cfR111-R116)
* Added a private `_warn_if_empty_response` method and integrated it into `ModelResponseConverter` to log when the wrapped response is `None` during both normal and streaming conversions. [[1]](diffhunk://#diff-e940ae46b82c89a4975df31d2001edef6232e397a57272fdb5b1de79ecf3e62cR77-R82) [[2]](diffhunk://#diff-e940ae46b82c89a4975df31d2001edef6232e397a57272fdb5b1de79ecf3e62cR103) [[3]](diffhunk://#diff-e940ae46b82c89a4975df31d2001edef6232e397a57272fdb5b1de79ecf3e62cR141)

**Test coverage for new warning logs:**

* Added tests in `tests/adapters/test_google_genai_converter.py` to verify that warnings are logged for missing choices in OpenAI responses and missing output items in OpenAI Responses API.
* Added tests in `tests/test_model_response_converter.py` to ensure warnings are logged when the response is `None` for both `invoke()` and `stream()` methods. [[1]](diffhunk://#diff-70532643057242d0bffd58558786c1b4bc9e0750bd16123997a89a5132539f29R75-R87) [[2]](diffhunk://#diff-70532643057242d0bffd58558786c1b4bc9e0750bd16123997a89a5132539f29R203-R223)

**Test setup improvements:**

* Updated imports in test files to include `logging` and use `MagicMock` where appropriate. [[1]](diffhunk://#diff-86ead85f5a42f622e798c1a9365897b04b66d36dcd838c3effedbf7935a8a280L5-R13) [[2]](diffhunk://#diff-70532643057242d0bffd58558786c1b4bc9e0750bd16123997a89a5132539f29L3-R9)