### PR TITLE
fix(llm): honor Vertex AI selection for client and eval judge

### DIFF
--- a/agentflow/core/llm/client_factory.py
+++ b/agentflow/core/llm/client_factory.py
@@ -131,7 +131,11 @@ def _create_google_client(*, use_vertex_ai: bool) -> Any:
             "for the Google provider."
         )
     logger.info("Creating Google GenAI client (API key)")
-    return genai.Client(api_key=api_key)
+    # Pass vertexai=False explicitly: google-genai's Client() otherwise reads the
+    # GOOGLE_GENAI_USE_VERTEXAI env var and silently switches to Vertex mode,
+    # which rejects API keys (401 UNAUTHENTICATED). The caller asked for the
+    # Developer API (use_vertex_ai=False), so honour that over the env.
+    return genai.Client(vertexai=False, api_key=api_key)
 
 
 def _create_openai_client(

--- a/agentflow/qa/evaluation/criteria/llm_utils.py
+++ b/agentflow/qa/evaluation/criteria/llm_utils.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 
 from agentflow.core.llm.caller import call_llm
 from agentflow.core.llm.client_factory import detect_provider
@@ -19,6 +20,22 @@ from agentflow.qa.evaluation.token_usage import TokenUsage
 
 
 logger = logging.getLogger("agentflow.evaluation")
+
+
+def _resolve_use_vertex_ai(config: object) -> bool:
+    """Decide whether the judge LLM should go through Vertex AI.
+
+    Honours an explicit ``use_vertex_ai`` on the criterion config when present,
+    otherwise falls back to the ``GOOGLE_GENAI_USE_VERTEXAI`` environment
+    variable — the same signal the agent runtime uses. Without this, the judge
+    always defaulted to the Gemini Developer API even when the project is only
+    reachable via Vertex, producing 401/403 auth failures and a silent 0.5
+    "No LLM provider available" score.
+    """
+    explicit = getattr(config, "use_vertex_ai", None)
+    if explicit is not None:
+        return bool(explicit)
+    return os.getenv("GOOGLE_GENAI_USE_VERTEXAI", "false").strip().lower() == "true"
 
 
 def _parse_model_provider(model: str, use_vertex_ai: bool = False) -> tuple[str, str]:
@@ -37,7 +54,7 @@ class LLMCallerMixin:
     async def _call_google_json(self, prompt: str) -> tuple[dict, TokenUsage] | None:
         """Call Google LLM and return (parsed JSON dict, token usage), or None if unavailable."""
         judge_model: str = self.config.judge_model  # type: ignore[attr-defined]
-        use_vertex_ai: bool = getattr(self.config, "use_vertex_ai", False)  # type: ignore[attr-defined]
+        use_vertex_ai: bool = _resolve_use_vertex_ai(self.config)
         try:
             text, inp, out, cache = await call_llm(
                 judge_model,
@@ -77,7 +94,7 @@ class LLMCallerMixin:
     async def _call_llm_json(self, prompt: str) -> tuple[dict, TokenUsage]:
         """Call the judge LLM and return (parsed JSON dict, token usage)."""
         judge_model: str = self.config.judge_model  # type: ignore[attr-defined]
-        use_vertex_ai: bool = getattr(self.config, "use_vertex_ai", False)  # type: ignore[attr-defined]
+        use_vertex_ai: bool = _resolve_use_vertex_ai(self.config)
         provider, _ = _parse_model_provider(judge_model, use_vertex_ai=use_vertex_ai)
 
         # Try provider-specific methods first


### PR DESCRIPTION
## Summary

Honor Google Vertex AI selection for both the LLM client and the evaluation judge. Surfaced while running evals against a Vertex-only project, where the Developer-API keys return 403 (project denied) and the judge always failed with a misleading `0.5` "No LLM provider available" score.

## Changes

- **`core/llm/client_factory.py`** — pass `vertexai=False` explicitly on the Developer-API branch so `google-genai`'s `Client()` can't read `GOOGLE_GENAI_USE_VERTEXAI` and silently switch to Vertex mode (which rejects API keys with `401 UNAUTHENTICATED`). The caller asked for the Developer API, so honor that over the env.
- **`qa/evaluation/criteria/llm_utils.py`** — the judge now resolves `use_vertex_ai` via a new `_resolve_use_vertex_ai` helper: explicit `use_vertex_ai` on the criterion config when present, otherwise the `GOOGLE_GENAI_USE_VERTEXAI` env var — the same signal the agent runtime already honors. Previously it hardcoded `False` and always hit the denied Developer-API keys.

## Testing

- `tests/evaluation` → **331 passed**
- `_resolve_use_vertex_ai` verified for explicit-config and env-fallback paths; both changed modules import cleanly
- Pre-commit (ruff, ruff-format, pyupgrade, etc.) pass on the changed files
