### PR TITLE
fix(agent): ensure fallback clients honor Vertex AI selection

### DIFF
--- a/agentflow/core/graph/agent.py
+++ b/agentflow/core/graph/agent.py
@@ -252,6 +252,9 @@ class Agent(
             ).lower()
             == "true",
         )  # legacy alias for provider="google"
+        # Persist so fallback clients (created lazily at call time) honour the
+        # same Vertex AI selection as the primary client.
+        self.use_vertex_ai = use_vertex_ai
         # Call parent constructor
         super().__init__(
             model=model,

--- a/agentflow/core/graph/agent_internal/execution.py
+++ b/agentflow/core/graph/agent_internal/execution.py
@@ -158,6 +158,10 @@ def _extract_response_text(response: Any) -> str:
 class AgentExecutionMixin:
     """Execution flow, tool resolution, and provider dispatch helpers."""
 
+    # Set by ``Agent.__init__``; declared here so the mixin can read it when
+    # lazily building fallback clients (the mixin never assigns it itself).
+    use_vertex_ai: bool
+
     def _setup_tools(self) -> ToolNode | None:
         """Normalize the tool_node input and wire internal state.
 
@@ -276,10 +280,10 @@ class AgentExecutionMixin:
 
         # Build the ordered attempt list: primary + fallbacks
         attempts: list[tuple[str, str, Any, str | None]] = [
-            (self.model, self.provider, self.client, getattr(self, "base_url", None)),
+            (self.model, self.provider, self.client, self.base_url),
         ]
         for fb_model, fb_provider in fallback_models:
-            attempts.append((fb_model, fb_provider or self.provider, None, None))
+            attempts.append((fb_model, fb_provider or self.provider, None, self.base_url))
 
         last_exc: Exception | None = None
 
@@ -301,14 +305,20 @@ class AgentExecutionMixin:
                             self.model,
                             self.provider,
                             self.client,
-                            getattr(self, "base_url", None),
+                            self.base_url,
                         )
                         self.model = model
                         self.provider = provider
                         self.base_url = base_url
                         active_client = fallback_client
                         if active_client is None:
-                            active_client = self._create_client(provider, base_url)
+                            # Lazily build the fallback client, honouring the
+                            # agent's Vertex AI selection (only affects google).
+                            active_client = self._create_client(
+                                provider,
+                                base_url,
+                                self.use_vertex_ai,
+                            )
                         self.client = active_client
                         try:
                             result = await self._call_llm(messages, tools, stream, **kwargs)


### PR DESCRIPTION
This pull request improves the handling of fallback LLM clients in the agent execution flow, ensuring that configuration for Vertex AI is consistently applied across both primary and fallback clients. The changes make the `use_vertex_ai` flag available throughout the agent and its execution mixin, and update the fallback client creation logic to respect this setting.

**Vertex AI configuration consistency:**

* The `use_vertex_ai` flag is now stored as an instance variable in `MyState` so that it can be accessed when creating fallback clients, ensuring consistent Vertex AI usage.
* The `AgentExecutionMixin` declares the `use_vertex_ai` attribute so it can be referenced during fallback client creation, even though it is only set by the main agent.
* When building fallback clients in `_call_llm_with_retry`, the code now passes the `use_vertex_ai` flag to `_create_client`, ensuring fallback clients honor the same Vertex AI selection as the primary client.

**Fallback client creation improvements:**

* The fallback client creation logic in `_call_llm_with_retry` is updated to always pass the correct `base_url` (previously could be `None`), improving consistency in client configuration.