### PR TITLE
refactor: simplify function definition for resolve_provider_and_model

### DIFF
--- a/agentflow/core/llm/client_factory.py
+++ b/agentflow/core/llm/client_factory.py
@@ -72,9 +72,7 @@ def detect_provider(model: str, use_vertex_ai: bool = False) -> str:
     return "openai"
 
 
-def resolve_provider_and_model(
-    model: str, use_vertex_ai: bool = False
-) -> tuple[str, str]:
+def resolve_provider_and_model(model: str, use_vertex_ai: bool = False) -> tuple[str, str]:
     """Resolve a model string into a concrete ``(provider, model)`` pair.
 
     Unlike :func:`detect_provider`, this also returns the model name that should

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,13 @@ def setup_test_environment():
     # Set dummy Google API key for tests
     os.environ.setdefault("GEMINI_API_KEY", "dummy-gemini-key-for-testing-only")
 
+    # Vertex AI selection must NOT be inherited from a developer's .env / shell.
+    # Agent() reads GOOGLE_GENAI_USE_VERTEXAI as the default for use_vertex_ai, so
+    # an ambient "true" would make provider auto-detection resolve to "google" for
+    # every model and break deterministic unit tests. Force it off for the suite;
+    # tests that exercise Vertex pass use_vertex_ai=True explicitly.
+    os.environ.pop("GOOGLE_GENAI_USE_VERTEXAI", None)
+
     # Keep tests compatible while core graph transitions from
     # Node(name, func, publisher) to Node(name, func).
     Node.__init__ = _compat_node_init

--- a/tests/normal_tests/test_custom_state_comprehensive.py
+++ b/tests/normal_tests/test_custom_state_comprehensive.py
@@ -6,16 +6,11 @@ Tests state transitions, checkpointing, and type safety.
 from dataclasses import dataclass, field
 from typing import Any
 
-from dotenv import load_dotenv
-
 from agentflow.storage.checkpointer import InMemoryCheckpointer
 from agentflow.core.graph import StateGraph
 from agentflow.core.state.agent_state import AgentState
 from agentflow.core.state import Message
 from agentflow.utils.converter import convert_messages
-
-
-load_dotenv()
 
 
 @dataclass


### PR DESCRIPTION
This pull request focuses on improving test reliability and code style in the codebase. The most significant changes ensure that environment variables do not cause nondeterministic behavior in tests, and unnecessary dependencies are removed for cleaner test files.

**Test environment reliability:**
- The test setup (`setup_test_environment` in `tests/conftest.py`) now explicitly unsets the `GOOGLE_GENAI_USE_VERTEXAI` environment variable to prevent accidental inheritance from developer environments. This ensures deterministic provider selection in tests and avoids unintended use of Vertex AI unless explicitly specified.

**Test code cleanup:**
- Removed the `dotenv` dependency and its usage from `tests/normal_tests/test_custom_state_comprehensive.py`, as environment variable loading is now handled centrally in the test setup.

**Code style and formatting:**
- Minor formatting change to the `resolve_provider_and_model` function signature in `agentflow/core/llm/client_factory.py` for consistency and readability.