### PR TITLE
Added Antropic AI Model Support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,6 +55,9 @@ Use these repo-specific notes to be productive quickly when generating code, doc
 - **Examples**: Most examples require an LLM API key (e.g., `OPENAI_API_KEY`) set in `.env` and a valid model string for your chosen provider.
 
 ## Optional integrations (extras in `pyproject.toml`)
+- `openai`, `google-genai`, `anthropic`: provider SDKs. Anthropic adds `anthropic-vertex` and
+  `anthropic-bedrock` for Claude on Vertex AI / Bedrock, selected with `anthropic_backend`.
+- `all`: every other extra at once, for development and CI.
 - `pg_checkpoint`: Postgres (`asyncpg`) + Redis cache (`redis`); use `checkpointer.PgCheckpointer`.
 - `mcp`: Model Context Protocol (FastMCP + mcp); pass an MCP client to `ToolNode`.
 - `composio`, `langchain`: adapters for external tool registries via `ToolNode`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,83 @@ Starting from this release:
 
 ## [Unreleased]
 
+### Added
+
+- **Native Anthropic provider.** `model="claude-opus-5"` (or `"anthropic/..."`,
+  `"claude/..."`) now builds a real Anthropic client instead of silently
+  constructing an `AsyncOpenAI` that failed at request time. Covers non-streaming
+  and streaming, tool calling, multimodal input, reasoning, usage accounting, and
+  retry/fallback. Install with the `anthropic`, `anthropic-vertex`, or
+  `anthropic-bedrock` extra.
+  - Three backends, selected with `anthropic_backend`: `None` (direct Claude API),
+    `"vertex"` (`AsyncAnthropicVertex`), `"bedrock"`
+    (`AsyncAnthropicBedrockMantle`, the Messages-API endpoint). Bedrock model ids
+    keep their `anthropic.` prefix.
+  - `max_tokens` is required by the API and is defaulted automatically (16000
+    non-streaming, 64000 streaming).
+  - `temperature`/`top_p`/`top_k` are stripped for models that reject them with a
+    400, per model rather than as a blanket strip.
+  - `reasoning_config={"effort": ...}` maps to `thinking={"type": "adaptive"}`
+    plus `output_config.effort`. `budget_tokens` is never emitted: it returns a
+    400 on current Claude models.
+  - A trailing assistant turn is dropped, since prefill returns a 400 on current
+    models. This specifically protects the injected `context_summary`.
+  - A policy `refusal` is a successful HTTP 200 with a possibly-empty `content`;
+    it is surfaced as a message with `metadata["refusal"]` rather than being
+    treated as a transient failure that burns the model fallback list.
+- **`Agent.count_tokens(messages, tools)`.** Counts a request's input tokens
+  before sending it, using the provider's own endpoint and the exact payload the
+  real call would send (system prompt, tool schemas, merged tool results). Only
+  Anthropic exposes a server-side counting endpoint today; other providers raise
+  `NotImplementedError` rather than returning a guess.
+- **Anthropic prompt caching.** `anthropic_cache=True` (or a dict such as
+  `{"type": "ephemeral", "ttl": "1h"}`) places `cache_control` breakpoints at the
+  end of the stable request prefix: the last tool and the last system block,
+  since render order is tools -> system -> messages. Skipped when the caller
+  placed their own breakpoints. Verify hits with
+  `usage.cache_read_input_tokens`; a prefix under ~1024 tokens silently does not
+  cache.
+- **Anthropic server tools.** `web_search_tool()`, `web_fetch_tool()`, and
+  `code_execution_tool()` build correctly-dated definitions, picking the
+  dynamic-filtering variant on models that support it and the basic variant
+  otherwise. Server-tool result blocks are captured into
+  `metadata["server_tool_results"]`, and a `server_tool_use` block is recorded
+  without being added to `tools_calls` so the graph does not re-run work
+  Anthropic already did. A server-tool error arrives as a normal HTTP 200 with an
+  error object rather than raising, and is surfaced as `error_code`.
+  `stop_reason: "pause_turn"` is flagged as `metadata["pause_turn"]`.
+- **`AnthropicBatch`** (`agentflow.core.llm.AnthropicBatch`) for the Message
+  Batches API: build, submit, poll, and collect. Results are keyed by
+  `custom_id` throughout, because batch results arrive in any order.
+- **`call_llm` supports Anthropic**, so `SummaryContextManager`, the evaluation
+  judge, and `UserSimulator` all work with Claude models.
+
+### Fixed
+
+- **`use_vertex_ai=True` hijacked Claude models.** The flag short-circuited
+  provider detection to `"google"` before the model name was examined, so
+  `Agent(model="claude-opus-5", use_vertex_ai=True)` built a Google GenAI client
+  with a Claude model name and failed at request time. Claude runs on Vertex too,
+  and `use_vertex_ai` is the flag a caller naturally reaches for, so it now acts
+  as a backend selector for Anthropic (equivalent to
+  `anthropic_backend="vertex"`) instead of a provider override. An explicit
+  `anthropic_backend` still wins. Behaviour for every non-Claude model is
+  unchanged.
+- **`call_llm` sent unrecognised model prefixes to the SDK verbatim.** It used
+  `detect_provider`, which selects a provider but does not strip the prefix, so
+  `call_llm("gemini/gemini-2.5-flash", ...)` passed the full string as the model
+  name. It now uses `resolve_provider_and_model`.
+
+### Breaking
+
+- **`anthropic/` and `claude/` are now recognised model prefixes.** Previously
+  they were unknown prefixes that fell through to the OpenAI provider, which was
+  how Claude-behind-an-OpenAI-compatible-proxy worked. `Agent(model=
+  "anthropic/claude-3")` now selects the native Anthropic provider and strips the
+  prefix. **Migration:** pass `provider="openai"` explicitly to keep routing
+  through an OpenAI-compatible endpoint:
+  `Agent(model="anthropic/claude-3", provider="openai", base_url=...)`.
+
 ## [1.0.0] - 2026-07-19
 
 First stable release. The public API is now covered by the deprecation policy above,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,11 +109,29 @@ message conversion, and tool integration. Key constructor params:
 `retry_config` (default True), `fallback_models`, `multimodal_config`, `output_schema`.
 
 **Model strings and providers.** `detect_provider(model)` infers the provider from a
-`"provider/model"` prefix or the model name. **It only resolves to `"google"` or `"openai"`.**
-Examples: `"gemini/gemini-2.5-flash"`, `"openai/gpt-4o"`, `"gpt-4o-mini"`. Vertex AI is selected
-via `use_vertex_ai=True`. There is **no native Anthropic client** in the LLM factory despite
-Anthropic/Claude appearing in marketing copy; Claude is reachable only via an OpenAI-compatible
-endpoint or the custom-functions approach. Verify before promising native Claude support.
+`"provider/model"` prefix or the model name, and resolves to `"google"`, `"openai"`, or
+`"anthropic"`. Examples: `"gemini/gemini-2.5-flash"`, `"openai/gpt-4o"`, `"gpt-4o-mini"`,
+`"claude-opus-5"`, `"anthropic/claude-sonnet-5"`. Google's Vertex AI is selected via
+`use_vertex_ai=True`.
+
+Anthropic has three backends, so a boolean flag cannot express them; the selector is the
+string `anthropic_backend`: `None` (direct Claude API, the default), `"vertex"`
+(`AsyncAnthropicVertex`), or `"bedrock"` (`AsyncAnthropicBedrockMantle`, the Messages-API
+endpoint, not the legacy `InvokeModel` client). Bedrock model ids keep their `anthropic.`
+prefix (`"anthropic.claude-opus-5"`); it is preserved, not stripped. Install with the
+`[anthropic]`, `[anthropic-vertex]`, or `[anthropic-bedrock]` extra.
+
+Anthropic-specific request behaviour, all handled by the provider and not the caller:
+`max_tokens` is required and defaulted (16000 non-streaming, 64000 streaming);
+`temperature`/`top_p`/`top_k` are stripped for models that reject them with a 400;
+`reasoning_config={"effort": ...}` maps to `thinking={"type": "adaptive"}` plus
+`output_config.effort`, and `budget_tokens` is never emitted; a trailing assistant turn is
+dropped because prefill 400s on current models. `output_type` is limited to `text` and
+`json`: the Messages API has no image/audio/video generation endpoint.
+
+Note the SDK is capped at `anthropic>=1.0.0,<2`. The 1.0 release moved to **httpx2**, so an
+`http_client` passed through `llm_kwargs` on the Anthropic path must be an httpx2 client,
+while the OpenAI path still takes httpx.
 
 **ToolNode.** `ToolNode(tools, client=None, pass_user_info_to_mcp=False)`. First positional arg
 is `tools` (an iterable of callables). `client` is an MCP client (fastmcp/mcp). Tools run in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ The importable package is `agentflow/agentflow/`. Top-level subpackages:
 |---|---|
 | `core/` | The engine. `graph/` (StateGraph, Agent, ToolNode, CompiledGraph, Node, Edge), `state/` (AgentState, Message, content blocks, reducers, context managers), `llm/` (provider detection + client factory + `call_llm`), `skills/` (dynamic skill injection), `exceptions/` |
 | `storage/` | `checkpointer/` (InMemory, Pg), `store/` (vector/long-term memory: Qdrant, Mem0, embeddings), `media/` (multimodal media processing, offload, resolvers, stores) |
-| `runtime/` | `adapters/llm/` (OpenAI / OpenAI-Responses / Google GenAI response converters), `publisher/` (Console, Redis, Kafka, RabbitMQ, OTEL, Composite), `protocols/` (a2a, acp) |
+| `runtime/` | `adapters/llm/` (OpenAI / OpenAI-Responses / Google GenAI / Anthropic response converters), `publisher/` (Console, Redis, Kafka, RabbitMQ, OTEL, Composite), `protocols/` (a2a, acp) |
 | `prebuilt/` | `agent/` (React, RAG, PlanActReflect, SupervisorTeam, Swarm, StructuredOutput), `tools/` (calculator, fetch, files, handoff, memory, search) |
 | `qa/` | `evaluation/` (criteria, datasets, evaluator, reporters, simulators) and `testing/` (TestAgent, mocks, quick tests) |
 | `utils/` | constants (START/END/ResponseGranularity), `tool` decorator, `convert_messages`, callbacks, validators, id generators, background tasks, graceful shutdown |
@@ -175,7 +175,7 @@ already present.
 .venv/bin/python -m pytest tests/graph   # one area
 ruff check . && ruff format .            # lint + format (line-length 100, py312)
 # editable install with extras for local dev:
-pip install -e ".[google-genai,openai,mcp,pg_checkpoint]"
+pip install -e ".[google-genai,openai,anthropic,mcp,pg_checkpoint]"
 ```
 
 - Tests live in `tests/` (mirrors package layout: `graph/`, `state/`, `storage/`, `store/`,
@@ -194,8 +194,6 @@ pip install -e ".[google-genai,openai,mcp,pg_checkpoint]"
 - **`ToolNode(functions=...)`** keyword is wrong (README MCP example). The param is `tools`.
 - A few `examples/` files still use dead paths (`agentflow.state.message`, `agentflow.graph.tool_node`,
   `agentflow.evaluation.*`). Treat those specific files as broken until fixed.
-- README/docstrings imply native Anthropic support; the LLM factory only builds google/openai
-  clients. See Model strings above.
 
 When you touch any of the above, prefer fixing the doc/example to match the code rather than the
 reverse, unless the export path itself is the bug.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ uv run pre-commit install   # enable the git hooks (optional but recommended)
 If you work on optional subsystems, install the matching extras, e.g.:
 
 ```bash
-uv pip install -e ".[google-genai,openai,mcp,pg_checkpoint]"
+uv pip install -e ".[google-genai,openai,anthropic,mcp,pg_checkpoint]"
 ```
 
 ## Before you open a pull request

--- a/README.md
+++ b/README.md
@@ -100,23 +100,26 @@ Provider SDKs and infrastructure integrations are optional extras — install on
 
 | Extra | Adds |
 |---|---|
-| `google-genai`, `openai` | Provider SDK adapters |
+| `google-genai`, `openai`, `anthropic` | Provider SDK adapters |
+| `anthropic-vertex`, `anthropic-bedrock` | Claude on Vertex AI or Amazon Bedrock |
 | `realtime` | Audio-to-audio agents over Gemini Live |
 | `mcp` | Model Context Protocol client and tools |
 | `pg_checkpoint`, `sqlite_checkpoint` | Durable checkpointing (Postgres + Redis, or SQLite) |
 | `qdrant`, `mem0` | Long-term vector memory stores |
 | `redis`, `kafka`, `rabbitmq`, `otel` | Event publishers and tracing |
 | `images`, `cloud-storage` | Multimodal media handling and offload |
+| `all` | Every extra above at once, for development and CI |
 
 ```bash
-pip install "10xscale-agentflow[google-genai,openai,mcp,pg_checkpoint]"
+pip install "10xscale-agentflow[google-genai,openai,anthropic,mcp,pg_checkpoint]"
 ```
 
 Then set your provider key. A `.env` file in the working directory is loaded automatically.
 
 ```bash
-export GEMINI_API_KEY=...     # Google Gemini
-export OPENAI_API_KEY=sk-...  # OpenAI, or any OpenAI-compatible endpoint
+export GEMINI_API_KEY=...        # Google Gemini
+export OPENAI_API_KEY=sk-...     # OpenAI, or any OpenAI-compatible endpoint
+export ANTHROPIC_API_KEY=sk-...  # Anthropic Claude
 ```
 
 ---

--- a/agentflow/core/graph/agent.py
+++ b/agentflow/core/graph/agent.py
@@ -14,6 +14,7 @@ from agentflow.core.skills.models import SkillConfig
 from agentflow.core.state.message import Message
 from agentflow.storage.media.config import MultimodalConfig
 
+from .agent_internal.anthropic import AgentAnthropicMixin
 from .agent_internal.constants import DEFAULT_RETRY_CONFIG, REASONING_DEFAULT, RetryConfig
 from .agent_internal.execution import AgentExecutionMixin
 from .agent_internal.google import AgentGoogleMixin
@@ -32,6 +33,7 @@ logger = logging.getLogger("agentflow.agent")
 
 class Agent(
     AgentExecutionMixin,
+    AgentAnthropicMixin,
     AgentGoogleMixin,
     AgentOpenAIMixin,
     AgentProviderMixin,

--- a/agentflow/core/graph/agent_internal/anthropic.py
+++ b/agentflow/core/graph/agent_internal/anthropic.py
@@ -1,0 +1,228 @@
+"""Anthropic request helpers for Agent."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .anthropic_request import (
+    apply_cache_control,
+    convert_tools,
+    drop_trailing_assistant,
+    merge_tool_results,
+    split_system,
+    strip_bedrock_prefix,
+)
+from .constants import (
+    ANTHROPIC_DEFAULT_MAX_TOKENS,
+    ANTHROPIC_DEFAULT_MAX_TOKENS_STREAMING,
+    ANTHROPIC_NO_SAMPLING_MODELS,
+    CALL_EXCLUDED_KWARGS,
+)
+
+
+logger = logging.getLogger("agentflow.agent")
+
+# Rejected with a 400 by the models in ANTHROPIC_NO_SAMPLING_MODELS.
+_SAMPLING_KEYS = ("temperature", "top_p", "top_k")
+
+# Anthropic-specific keys that agentflow threads through llm_kwargs but which are
+# not request parameters.
+_ANTHROPIC_EXCLUDED_KWARGS = CALL_EXCLUDED_KWARGS | frozenset(
+    {
+        "anthropic_backend",
+        "anthropic_cache",
+        "reasoning_effort",
+        "auth_token",
+        "middleware",
+    }
+)
+
+
+def strip_rejected_sampling_params(model: str, call_kwargs: dict[str, Any]) -> None:
+    """Drop temperature/top_p/top_k for models that 400 on them, in place."""
+    if strip_bedrock_prefix(model) not in ANTHROPIC_NO_SAMPLING_MODELS:
+        return
+
+    dropped = [key for key in _SAMPLING_KEYS if key in call_kwargs]
+    if not dropped:
+        return
+
+    for key in dropped:
+        call_kwargs.pop(key)
+    logger.warning(
+        "Model %s rejects sampling parameters; dropped %s from the request. "
+        "Use reasoning_config effort to control depth instead.",
+        model,
+        ", ".join(dropped),
+    )
+
+
+def apply_reasoning_config(
+    reasoning_config: dict[str, Any] | None,
+    call_kwargs: dict[str, Any],
+) -> None:
+    """Map agentflow's reasoning_config onto Anthropic thinking/effort, in place.
+
+    ``budget_tokens`` is never emitted: it is removed on every current Claude
+    model and returns a 400. Depth is controlled by ``output_config.effort``.
+    """
+    if not reasoning_config:
+        return
+
+    call_kwargs.setdefault("thinking", {"type": "adaptive"})
+
+    effort = reasoning_config.get("effort")
+    if effort:
+        output_config = dict(call_kwargs.get("output_config") or {})
+        output_config.setdefault("effort", effort)
+        call_kwargs["output_config"] = output_config
+
+    if reasoning_config.get("thinking_budget") or reasoning_config.get("budget_tokens"):
+        logger.warning(
+            "budget_tokens/thinking_budget is not supported by current Claude "
+            "models and would return a 400; ignoring it. Use "
+            "reasoning_config={'effort': ...} instead."
+        )
+
+
+class AgentAnthropicMixin:
+    """Anthropic Messages API request helpers."""
+
+    def _build_anthropic_request(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list | None = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        """Assemble the ``(messages, kwargs)`` pair for a Messages API call.
+
+        Shared by the request path and ``count_tokens`` so a token count is
+        taken against exactly the payload that would be sent, not an
+        approximation of it.
+        """
+        call_kwargs = {
+            key: value
+            for key, value in {**self.llm_kwargs, **kwargs}.items()
+            if key not in _ANTHROPIC_EXCLUDED_KWARGS
+        }
+
+        system, remainder = split_system(messages)
+        remainder = merge_tool_results(remainder)
+        remainder = drop_trailing_assistant(remainder)
+
+        # max_tokens is required by the API. Streaming gets a larger default
+        # because a big max_tokens on a non-streaming request risks a timeout.
+        call_kwargs.setdefault(
+            "max_tokens",
+            ANTHROPIC_DEFAULT_MAX_TOKENS_STREAMING if stream else ANTHROPIC_DEFAULT_MAX_TOKENS,
+        )
+
+        strip_rejected_sampling_params(self.model, call_kwargs)
+        apply_reasoning_config(getattr(self, "reasoning_config", None), call_kwargs)
+
+        anthropic_tools = convert_tools(tools)
+
+        # Prefix-stable caching. Skipped when the caller placed their own
+        # cache_control breakpoints, so an explicit strategy is never doubled.
+        if "cache_control" not in call_kwargs:
+            apply_cache_control(self.llm_kwargs.get("anthropic_cache"), system, anthropic_tools)
+
+        if anthropic_tools:
+            call_kwargs["tools"] = anthropic_tools
+        if system:
+            call_kwargs["system"] = system
+
+        output_schema = getattr(self, "output_schema", None)
+        if output_schema is not None:
+            call_kwargs.setdefault("output_config", {})
+            call_kwargs["output_config"] = {
+                **call_kwargs["output_config"],
+                "format": _as_json_schema_format(output_schema),
+            }
+
+        return remainder, call_kwargs
+
+    async def _call_anthropic(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list | None = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Call the Anthropic Messages API."""
+        remainder, call_kwargs = self._build_anthropic_request(messages, tools, stream, **kwargs)
+
+        if stream:
+            logger.debug("Calling Anthropic messages.stream with model=%s", self.model)
+            return self.client.messages.stream(
+                model=self.model,
+                messages=remainder,
+                **call_kwargs,
+            )
+
+        logger.debug("Calling Anthropic messages.create with model=%s", self.model)
+        response = await self.client.messages.create(
+            model=self.model,
+            messages=remainder,
+            **call_kwargs,
+        )
+
+        usage = getattr(response, "usage", None)
+        cached = getattr(usage, "cache_read_input_tokens", 0) or 0
+        if cached:
+            logger.debug("Cache hit: %d cached tokens (Anthropic messages)", cached)
+
+        if getattr(response, "stop_reason", None) == "pause_turn":
+            logger.info(
+                "Anthropic returned stop_reason='pause_turn' (server-tool "
+                "iteration limit). Re-send the conversation including this "
+                "response to resume."
+            )
+        return response
+
+    async def _count_tokens_anthropic(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """Count input tokens for a request via ``messages.count_tokens``.
+
+        Counted against the exact payload ``_call_anthropic`` would send, so the
+        number reflects the real system prompt, tool schemas, and merged tool
+        results rather than an estimate.
+        """
+        remainder, call_kwargs = self._build_anthropic_request(
+            messages, tools, stream=False, **kwargs
+        )
+
+        # count_tokens prices the input; generation-side parameters are not part
+        # of its request shape and are rejected.
+        for key in ("max_tokens", "stream", "output_config", "temperature", "top_p", "top_k"):
+            call_kwargs.pop(key, None)
+
+        response = await self.client.messages.count_tokens(
+            model=self.model,
+            messages=remainder,
+            **call_kwargs,
+        )
+        return getattr(response, "input_tokens", 0) or 0
+
+
+def _as_json_schema_format(output_schema: Any) -> dict[str, Any]:
+    """Render an output schema into Anthropic's ``output_config.format`` shape."""
+    if isinstance(output_schema, dict):
+        return output_schema
+
+    # Pydantic model
+    schema_fn = getattr(output_schema, "model_json_schema", None)
+    if callable(schema_fn):
+        return {
+            "type": "json_schema",
+            "schema": schema_fn(),
+            "name": getattr(output_schema, "__name__", "output"),
+        }
+
+    return {"type": "json_schema", "schema": {}}

--- a/agentflow/core/graph/agent_internal/anthropic.py
+++ b/agentflow/core/graph/agent_internal/anthropic.py
@@ -89,6 +89,14 @@ def apply_reasoning_config(
 class AgentAnthropicMixin:
     """Anthropic Messages API request helpers."""
 
+    # Instance attributes set by BaseAgent.__init__ (model, llm_kwargs) and
+    # Agent.__init__ (client). Declared here so the mixin type-checks on its own;
+    # reasoning_config and output_schema are read with getattr because they are
+    # optional on the concrete agent.
+    model: str
+    client: Any
+    llm_kwargs: dict[str, Any]
+
     def _build_anthropic_request(
         self,
         messages: list[dict[str, Any]],

--- a/agentflow/core/graph/agent_internal/anthropic_request.py
+++ b/agentflow/core/graph/agent_internal/anthropic_request.py
@@ -1,0 +1,387 @@
+"""Pure request translation for the Anthropic Messages API.
+
+Every function here is side-effect free: no client, no network, no ``AgentState``.
+Agentflow speaks an OpenAI-shaped internal dialect (system messages inside the
+message list, ``tool_calls`` arrays, one ``role: "tool"`` message per result).
+Anthropic wants something structurally different, and this module is the whole of
+that difference so it can be tested exhaustively without a request.
+
+The four structural gaps:
+
+===========================  ==========================================
+Agentflow (OpenAI-shaped)    Anthropic
+===========================  ==========================================
+``role: "system"`` messages  top-level ``system=`` parameter
+``tool_calls`` array         ``tool_use`` content blocks
+one ``role: "tool"`` each    all ``tool_result`` blocks in ONE user turn
+``{"type": "function"...}``  ``{"name", "description", "input_schema"}``
+===========================  ==========================================
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+
+logger = logging.getLogger("agentflow.agent.anthropic")
+
+# Content part types Anthropic has no equivalent for. Dropped with a warning,
+# matching how the OpenAI path degrades video rather than inventing a failure.
+_UNSUPPORTED_PART_TYPES = ("input_audio", "video")
+
+_DATA_URI_PREFIX = "data:"
+
+_BEDROCK_PREFIX = "anthropic."
+
+
+def strip_bedrock_prefix(model: str) -> str:
+    """Strip a Bedrock ``anthropic.`` prefix for capability lookups only.
+
+    The prefix is part of the real Bedrock model id and must be preserved in the
+    string actually sent to the client, so this is for set-membership checks
+    (does this model reject sampling params?), never for building the request.
+    """
+    return model[len(_BEDROCK_PREFIX) :] if model.startswith(_BEDROCK_PREFIX) else model
+
+
+def split_system(
+    messages: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]] | None, list[dict[str, Any]]]:
+    """Split ``role: "system"`` entries out into Anthropic's top-level ``system``.
+
+    Anthropic takes the system prompt as a separate request parameter, not as a
+    message. Multiple system prompts become a list of text blocks rather than
+    being concatenated, because that list is also the correct attachment point
+    for ``cache_control`` breakpoints later.
+
+    Returns:
+        A ``(system, messages)`` tuple. ``system`` is ``None`` when the input
+        carried no system prompt.
+    """
+    system_blocks: list[dict[str, Any]] = []
+    remainder: list[dict[str, Any]] = []
+
+    for message in messages:
+        if message.get("role") != "system":
+            remainder.append(message)
+            continue
+
+        content = message.get("content", "")
+        if isinstance(content, str):
+            if content:
+                system_blocks.append({"type": "text", "text": content})
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    system_blocks.append({"type": "text", "text": part.get("text", "")})
+                elif isinstance(part, str):
+                    system_blocks.append({"type": "text", "text": part})
+        elif content:
+            system_blocks.append({"type": "text", "text": str(content)})
+
+    return (system_blocks or None), remainder
+
+
+def convert_content_parts(content: Any) -> Any:
+    """Convert internal content parts into Anthropic content blocks.
+
+    A plain string passes through unchanged: Anthropic accepts a bare string as
+    message content, so there is no reason to wrap it.
+    """
+    if not isinstance(content, list):
+        return content
+
+    converted: list[dict[str, Any]] = []
+    for part in content:
+        if not isinstance(part, dict):
+            converted.append({"type": "text", "text": str(part)})
+            continue
+
+        ptype = part.get("type", "")
+
+        if ptype == "text":
+            converted.append({"type": "text", "text": part.get("text", "")})
+
+        elif ptype == "image_url":
+            block = _convert_image_part(part)
+            if block is not None:
+                converted.append(block)
+
+        elif ptype == "document":
+            converted.append(_convert_document_part(part))
+
+        elif ptype in _UNSUPPORTED_PART_TYPES:
+            logger.warning(
+                "Anthropic has no %s content block; dropping this part from the request.",
+                ptype,
+            )
+
+        else:
+            # Already-Anthropic-shaped blocks (text, image, document, tool_use,
+            # tool_result, thinking) pass through untouched.
+            converted.append(part)
+
+    return converted
+
+
+def _convert_image_part(part: dict[str, Any]) -> dict[str, Any] | None:
+    """Convert an OpenAI ``image_url`` part into an Anthropic ``image`` block."""
+    image_info = part.get("image_url", {})
+    url = image_info.get("url", "") if isinstance(image_info, dict) else str(image_info)
+
+    if not url:
+        logger.warning("Dropping image content part with no URL.")
+        return None
+
+    if url.startswith(_DATA_URI_PREFIX):
+        media_type, data = _parse_data_uri(url)
+        if data is None:
+            logger.warning("Dropping malformed image data URI.")
+            return None
+        return {
+            "type": "image",
+            "source": {"type": "base64", "media_type": media_type, "data": data},
+        }
+
+    return {"type": "image", "source": {"type": "url", "url": url}}
+
+
+def _convert_document_part(part: dict[str, Any]) -> dict[str, Any]:
+    """Convert a ``document`` part into an Anthropic ``document`` (or text) block.
+
+    Documents that already carry extracted text degrade to a text block, which is
+    what the OpenAI path does too: re-sending the raw PDF when the text is already
+    in hand only costs tokens.
+    """
+    doc_info = part.get("document", {})
+    if not isinstance(doc_info, dict):
+        return {"type": "text", "text": str(doc_info)}
+
+    if doc_info.get("text"):
+        return {"type": "text", "text": doc_info["text"]}
+
+    url = doc_info.get("url", "")
+    if url.startswith(_DATA_URI_PREFIX):
+        media_type, data = _parse_data_uri(url)
+        if data is not None:
+            return {
+                "type": "document",
+                "source": {"type": "base64", "media_type": media_type, "data": data},
+            }
+    elif url:
+        return {"type": "document", "source": {"type": "url", "url": url}}
+
+    return {"type": "text", "text": str(doc_info)}
+
+
+def _parse_data_uri(url: str) -> tuple[str, str | None]:
+    """Split a ``data:<media_type>;base64,<payload>`` URI.
+
+    Returns ``(media_type, payload)``; payload is ``None`` when the URI is
+    malformed. Defaults the media type when the URI omits it.
+    """
+    try:
+        header, payload = url.split(",", 1)
+    except ValueError:
+        return "application/octet-stream", None
+
+    meta = header[len(_DATA_URI_PREFIX) :]
+    media_type = meta.split(";", 1)[0] or "application/octet-stream"
+    return media_type, payload
+
+
+def convert_tools(tools: list[Any] | None) -> list[dict[str, Any]] | None:
+    """Unwrap OpenAI-shaped tool definitions into Anthropic's flat shape.
+
+    Entries that are already Anthropic-shaped pass through untouched, so server
+    tools (``web_search_20260209`` and friends) and MCP toolsets are not mangled.
+    """
+    if not tools:
+        return None
+
+    converted: list[dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            converted.append(tool)
+            continue
+
+        function = tool.get("function")
+        if tool.get("type") == "function" and isinstance(function, dict):
+            entry: dict[str, Any] = {
+                "name": function.get("name", ""),
+                "description": function.get("description", ""),
+                "input_schema": function.get("parameters") or {"type": "object", "properties": {}},
+            }
+            # ``strict`` is a top-level field on an Anthropic tool, not nested.
+            if function.get("strict") is not None:
+                entry["strict"] = function["strict"]
+            converted.append(entry)
+        else:
+            converted.append(tool)
+
+    return converted
+
+
+def convert_assistant_tool_calls(message: dict[str, Any]) -> dict[str, Any]:
+    """Turn an assistant ``tool_calls`` array into ``tool_use`` content blocks."""
+    blocks: list[dict[str, Any]] = []
+
+    content = message.get("content")
+    if content:
+        converted = convert_content_parts(content)
+        if isinstance(converted, str):
+            blocks.append({"type": "text", "text": converted})
+        elif isinstance(converted, list):
+            blocks.extend(converted)
+
+    for tool_call in message.get("tool_calls") or []:
+        function = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
+        raw_args = function.get("arguments", "{}")
+        blocks.append(
+            {
+                "type": "tool_use",
+                "id": tool_call.get("id", ""),
+                "name": function.get("name", ""),
+                "input": _parse_tool_arguments(raw_args),
+            }
+        )
+
+    return {"role": "assistant", "content": blocks}
+
+
+def _parse_tool_arguments(raw: Any) -> dict[str, Any]:
+    """Parse tool-call arguments into an object.
+
+    Agentflow carries arguments as a JSON *string* (the OpenAI shape); Anthropic
+    wants a decoded object. Never string-match these: current Claude models vary
+    their JSON escaping, so they must go through a real parser.
+    """
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        logger.warning("Could not parse tool call arguments as JSON: %r", raw)
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def merge_tool_results(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse consecutive ``role: "tool"`` messages into one user turn.
+
+    This is the one structurally non-mechanical transform. Agentflow emits one
+    ``role: "tool"`` message per tool call. Anthropic requires every
+    ``tool_result`` for a given assistant turn to arrive in a **single**
+    ``role: "user"`` message. Splitting them across messages is accepted by the
+    API but degrades parallel tool calling, so they must be merged rather than
+    emitted one apiece.
+    """
+    merged: list[dict[str, Any]] = []
+    pending: list[dict[str, Any]] = []
+
+    def flush() -> None:
+        if pending:
+            merged.append({"role": "user", "content": list(pending)})
+            pending.clear()
+
+    for message in messages:
+        role = message.get("role")
+
+        if role == "tool":
+            pending.append(_to_tool_result_block(message))
+            continue
+
+        flush()
+
+        if role == "assistant" and message.get("tool_calls"):
+            merged.append(convert_assistant_tool_calls(message))
+        else:
+            merged.append(
+                {
+                    "role": role,
+                    "content": convert_content_parts(message.get("content", "")),
+                }
+            )
+
+    flush()
+    return merged
+
+
+def _to_tool_result_block(message: dict[str, Any]) -> dict[str, Any]:
+    """Build a single ``tool_result`` block from a ``role: "tool"`` message."""
+    block: dict[str, Any] = {
+        "type": "tool_result",
+        "tool_use_id": message.get("tool_call_id", ""),
+        "content": _stringify_tool_content(message.get("content", "")),
+    }
+    if message.get("is_error"):
+        block["is_error"] = True
+    return block
+
+
+def _stringify_tool_content(content: Any) -> Any:
+    """Normalise tool result content into something Anthropic accepts."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return convert_content_parts(content)
+    return str(content)
+
+
+def apply_cache_control(
+    cache: bool | dict[str, Any] | None,
+    system: list[dict[str, Any]] | None,
+    tools: list[dict[str, Any]] | None,
+) -> None:
+    """Attach ``cache_control`` breakpoints to the stable request prefix, in place.
+
+    Caching is a **prefix match**: the render order is ``tools`` -> ``system`` ->
+    ``messages``, and any byte change invalidates everything after it. So the
+    breakpoint goes at the end of the stable prefix (the last tool if tools are
+    present, and the last system block), leaving the volatile per-request
+    messages after it.
+
+    Args:
+        cache: ``False``/``None`` disables. ``True`` uses a default ephemeral
+            breakpoint. A dict is used verbatim as the ``cache_control`` value,
+            so ``{"type": "ephemeral", "ttl": "1h"}`` extends retention.
+        system: System blocks, mutated in place.
+        tools: Anthropic-shaped tool definitions, mutated in place.
+
+    Note:
+        The minimum cacheable prefix is roughly 1024 tokens; a shorter prefix
+        silently does not cache. Verify with ``usage.cache_read_input_tokens``.
+    """
+    if not cache:
+        return
+
+    control = cache if isinstance(cache, dict) else {"type": "ephemeral"}
+
+    # Tools render first, so a breakpoint on the last tool caches the whole
+    # tool list. Only worth it when the system prompt is also stable.
+    if tools:
+        tools[-1] = {**tools[-1], "cache_control": control}
+
+    if system:
+        system[-1] = {**system[-1], "cache_control": control}
+
+
+def drop_trailing_assistant(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Remove a trailing assistant turn, which Anthropic rejects as a prefill.
+
+    Assistant prefills return a 400 on every current Claude model. This matters
+    specifically because agentflow injects ``state.context_summary`` as an
+    assistant message, which becomes the trailing turn whenever ``state.context``
+    is empty.
+    """
+    if messages and messages[-1].get("role") == "assistant":
+        logger.debug(
+            "Dropping trailing assistant message: Anthropic rejects assistant "
+            "prefills with a 400 on current models."
+        )
+        return messages[:-1]
+    return messages

--- a/agentflow/core/graph/agent_internal/anthropic_server_tools.py
+++ b/agentflow/core/graph/agent_internal/anthropic_server_tools.py
@@ -1,0 +1,134 @@
+"""Anthropic server-side tool definitions.
+
+Server tools run on Anthropic's infrastructure: you declare them in ``tools``
+and the results arrive as content blocks in the same response. There is no
+client-side execution loop, so they never reach agentflow's ``ToolNode``.
+
+Tool ``type`` strings are dated and model-gated. The builders here pick the
+right variant for the model rather than making callers memorise which dated
+string a given model accepts.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .anthropic_request import strip_bedrock_prefix
+
+
+logger = logging.getLogger("agentflow.agent.anthropic")
+
+# Models supporting the dynamic-filtering web tool variants.
+_DYNAMIC_FILTER_MODELS = frozenset(
+    {
+        "claude-fable-5",
+        "claude-mythos-5",
+        "claude-opus-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-5",
+        "claude-sonnet-4-6",
+    }
+)
+
+WEB_SEARCH_DYNAMIC = "web_search_20260209"
+WEB_SEARCH_BASIC = "web_search_20250305"
+WEB_FETCH_DYNAMIC = "web_fetch_20260209"
+WEB_FETCH_BASIC = "web_fetch_20250910"
+CODE_EXECUTION = "code_execution_20260521"
+
+# The matching *result* block types live with the response converter
+# (``runtime.adapters.llm.anthropic_converter.SERVER_TOOL_RESULT_TYPES``); that
+# package is imported by this one, so the dependency only runs one way.
+
+
+def _supports_dynamic_filtering(model: str) -> bool:
+    return strip_bedrock_prefix(model) in _DYNAMIC_FILTER_MODELS
+
+
+def web_search_tool(
+    model: str,
+    *,
+    max_uses: int | None = None,
+    allowed_domains: list[str] | None = None,
+    blocked_domains: list[str] | None = None,
+    user_location: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a ``web_search`` server tool definition for *model*.
+
+    Newer models get the dynamic-filtering variant, which runs code execution
+    under the hood. Do **not** also declare a separate ``code_execution`` tool
+    alongside it: two execution environments confuse the model.
+
+    ``allowed_domains`` and ``blocked_domains`` are mutually exclusive.
+    """
+    if allowed_domains and blocked_domains:
+        raise ValueError("web_search accepts allowed_domains or blocked_domains, never both.")
+
+    tool: dict[str, Any] = {
+        "type": WEB_SEARCH_DYNAMIC if _supports_dynamic_filtering(model) else WEB_SEARCH_BASIC,
+        "name": "web_search",
+    }
+    if max_uses is not None:
+        tool["max_uses"] = max_uses
+    if allowed_domains:
+        tool["allowed_domains"] = allowed_domains
+    if blocked_domains:
+        tool["blocked_domains"] = blocked_domains
+    if user_location:
+        tool["user_location"] = user_location
+    return tool
+
+
+def web_fetch_tool(
+    model: str,
+    *,
+    max_uses: int | None = None,
+    allowed_domains: list[str] | None = None,
+    blocked_domains: list[str] | None = None,
+    citations: dict[str, Any] | None = None,
+    max_content_tokens: int | None = None,
+) -> dict[str, Any]:
+    """Build a ``web_fetch`` server tool definition for *model*.
+
+    Web fetch only retrieves URLs already present in the conversation.
+    """
+    if allowed_domains and blocked_domains:
+        raise ValueError("web_fetch accepts allowed_domains or blocked_domains, never both.")
+
+    tool: dict[str, Any] = {
+        "type": WEB_FETCH_DYNAMIC if _supports_dynamic_filtering(model) else WEB_FETCH_BASIC,
+        "name": "web_fetch",
+    }
+    if max_uses is not None:
+        tool["max_uses"] = max_uses
+    if allowed_domains:
+        tool["allowed_domains"] = allowed_domains
+    if blocked_domains:
+        tool["blocked_domains"] = blocked_domains
+    if citations:
+        tool["citations"] = citations
+    if max_content_tokens is not None:
+        tool["max_content_tokens"] = max_content_tokens
+    return tool
+
+
+def code_execution_tool() -> dict[str, Any]:
+    """Build a ``code_execution`` server tool definition.
+
+    Returns ``bash_code_execution_tool_result`` blocks, not the legacy bare
+    ``code_execution_tool_result``.
+    """
+    return {"type": CODE_EXECUTION, "name": "code_execution"}
+
+
+def is_server_tool(tool: Any) -> bool:
+    """True when *tool* is already an Anthropic server-tool definition."""
+    if not isinstance(tool, dict):
+        return False
+    ttype = tool.get("type", "")
+    return isinstance(ttype, str) and ttype.startswith(
+        ("web_search_", "web_fetch_", "code_execution_", "tool_search_tool_")
+    )

--- a/agentflow/core/graph/agent_internal/constants.py
+++ b/agentflow/core/graph/agent_internal/constants.py
@@ -62,6 +62,29 @@ CALL_EXCLUDED_KWARGS = CLIENT_CONSTRUCTOR_KWARGS | frozenset(
 VALID_OUTPUT_TYPES = ("text", "image", "video", "audio", "json")
 GOOGLE_OUTPUT_TYPES = ("text", "image", "video", "audio", "json")
 OPENAI_OUTPUT_TYPES = ("text", "image", "audio", "json")
+# Anthropic's Messages API generates text and tool calls only. Structured output
+# is text constrained by a JSON schema, so "json" is supported; there is no
+# image/audio/video generation endpoint.
+ANTHROPIC_OUTPUT_TYPES = ("text", "json")
+
+# Models that reject temperature / top_p / top_k with a 400. Sampling params are
+# stripped for these before the request is sent. Older Claude models still accept
+# them, so this is a per-model set rather than a blanket strip.
+ANTHROPIC_NO_SAMPLING_MODELS = frozenset(
+    {
+        "claude-fable-5",
+        "claude-mythos-5",
+        "claude-opus-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-5",
+    }
+)
+
+# Anthropic requires max_tokens on every request. Streaming gets a larger default:
+# a large max_tokens without streaming risks an HTTP timeout.
+ANTHROPIC_DEFAULT_MAX_TOKENS = 16000
+ANTHROPIC_DEFAULT_MAX_TOKENS_STREAMING = 64000
 
 GOOGLE_THINKING_BUDGET_BY_EFFORT = {
     "low": 512,

--- a/agentflow/core/graph/agent_internal/execution.py
+++ b/agentflow/core/graph/agent_internal/execution.py
@@ -579,6 +579,12 @@ class AgentExecutionMixin:
         Returns:
             The input token count.
 
+        Note:
+            Coverage differs by provider. Anthropic's endpoint counts messages,
+            the system prompt, and tool schemas. Google's counts ``contents``
+            only, since its endpoint takes no system instruction or tools, so
+            the total is lower than what the request will actually bill.
+
         Raises:
             NotImplementedError: If the active provider exposes no server-side
                 token counting endpoint.
@@ -586,12 +592,15 @@ class AgentExecutionMixin:
         if self.provider == "anthropic":
             return await self._count_tokens_anthropic(messages, tools, **kwargs)
 
+        if self.provider == "google":
+            return await self._count_tokens_google(messages, tools, **kwargs)
+
         raise NotImplementedError(
             f"Provider '{self.provider}' has no server-side token counting "
-            "endpoint, so an exact count is not available. Only 'anthropic' "
-            "supports Agent.count_tokens() today. Read usage from the response "
-            "after the call instead, or count client-side with the tokenizer "
-            "matching your model."
+            "endpoint, so an exact count is not available. 'anthropic' and "
+            "'google' support Agent.count_tokens(); OpenAI does not expose one. "
+            "Read usage from the response after the call instead, or count "
+            "client-side with the tokenizer matching your model."
         )
 
     async def execute(

--- a/agentflow/core/graph/agent_internal/execution.py
+++ b/agentflow/core/graph/agent_internal/execution.py
@@ -487,7 +487,7 @@ class AgentExecutionMixin:
         assert last_exc is not None  # noqa: S101
         raise last_exc
 
-    async def _call_llm(
+    async def _call_llm(  # noqa: PLR0911
         self,
         messages: list[dict[str, Any]],
         tools: list | None = None,
@@ -553,7 +553,46 @@ class AgentExecutionMixin:
         if self.provider == "google":
             return await self._call_google(messages, tools, stream, **kwargs)
 
+        if self.provider == "anthropic":
+            return await self._call_anthropic(messages, tools, stream, **kwargs)
+
         raise ValueError(f"Unsupported provider: {self.provider}")
+
+    async def count_tokens(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """Count the input tokens a request would consume, before sending it.
+
+        Uses the provider's own counting endpoint, so the number accounts for
+        the system prompt, tool schemas, and content blocks exactly as the real
+        request would encode them. Useful for budgeting a call, deciding whether
+        to trim context, or estimating cost up front.
+
+        Args:
+            messages: Messages in agentflow's internal (OpenAI-shaped) dialect.
+            tools: Optional tool definitions, which are part of the counted input.
+            **kwargs: Extra request parameters, matching ``_call_llm``.
+
+        Returns:
+            The input token count.
+
+        Raises:
+            NotImplementedError: If the active provider exposes no server-side
+                token counting endpoint.
+        """
+        if self.provider == "anthropic":
+            return await self._count_tokens_anthropic(messages, tools, **kwargs)
+
+        raise NotImplementedError(
+            f"Provider '{self.provider}' has no server-side token counting "
+            "endpoint, so an exact count is not available. Only 'anthropic' "
+            "supports Agent.count_tokens() today. Read usage from the response "
+            "after the call instead, or count client-side with the tokenizer "
+            "matching your model."
+        )
 
     async def execute(
         self,

--- a/agentflow/core/graph/agent_internal/google.py
+++ b/agentflow/core/graph/agent_internal/google.py
@@ -403,6 +403,31 @@ class AgentGoogleMixin:
             logger.debug("Cache hit: %d cached tokens (Google)", cached)
         return response
 
+    async def _count_tokens_google(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list | None = None,
+        **kwargs: Any,
+    ) -> int:
+        """Count input tokens via the Google GenAI ``count_tokens`` endpoint.
+
+        Counted against the same converted ``contents`` the real request would
+        send, so multimodal parts and tool-call history are included rather than
+        estimated.
+
+        Note:
+            Google counts ``contents``; the system instruction and tool schemas
+            are not part of this endpoint's request shape, so they are excluded
+            from the total. Anthropic's equivalent does include them.
+        """
+        _system_instruction, google_contents = self._convert_to_google_format(messages)
+
+        response = await self.client.aio.models.count_tokens(
+            model=self.model,
+            contents=google_contents,
+        )
+        return getattr(response, "total_tokens", 0) or 0
+
     async def _call_google(
         self,
         messages: list[dict[str, Any]],

--- a/agentflow/core/graph/agent_internal/providers.py
+++ b/agentflow/core/graph/agent_internal/providers.py
@@ -12,6 +12,7 @@ from agentflow.core.llm.client_factory import (
 )
 
 from .constants import (
+    ANTHROPIC_OUTPUT_TYPES,
     CLIENT_CONSTRUCTOR_KWARGS,
     GOOGLE_OUTPUT_TYPES,
     OPENAI_OUTPUT_TYPES,
@@ -51,6 +52,14 @@ class AgentProviderMixin:
                 f"Supported: {list(OPENAI_OUTPUT_TYPES)}"
             )
 
+        if self.provider == "anthropic" and self.output_type not in ANTHROPIC_OUTPUT_TYPES:
+            raise ValueError(
+                f"Anthropic provider doesn't support output_type='{self.output_type}'. "
+                f"Supported: {list(ANTHROPIC_OUTPUT_TYPES)}. Anthropic's Messages API "
+                "generates text and tool calls only; there is no image/audio/video "
+                "generation endpoint."
+            )
+
         logger.debug("%s provider supports output_type='%s'", self.provider, self.output_type)
 
     def _detect_provider_from_model(self, model: str, use_vertex_ai: bool = False) -> str:
@@ -80,6 +89,26 @@ class AgentProviderMixin:
     ) -> Any:
         """Create a native SDK client for the selected provider."""
         api_key = self.llm_kwargs.get("api_key")
+        if provider == "anthropic":
+            # Anthropic's constructors reject the OpenAI-shaped allowlist, so the
+            # factory does its own per-backend filtering; pass llm_kwargs through.
+            # use_vertex_ai is honoured as a backend selector so the flag means
+            # the same thing for Claude as it does for Gemini.
+            backend = self.llm_kwargs.get("anthropic_backend")
+            if backend is None and use_vertex_ai:
+                backend = "vertex"
+            return create_llm_client(
+                provider,
+                base_url=base_url,
+                api_key=api_key,
+                anthropic_backend=backend,
+                **{
+                    k: v
+                    for k, v in self.llm_kwargs.items()
+                    if k not in ("api_key", "anthropic_backend", "base_url")
+                },
+            )
+
         extra = {k: v for k, v in self.llm_kwargs.items() if k in CLIENT_CONSTRUCTOR_KWARGS}
         return create_llm_client(
             provider,

--- a/agentflow/core/llm/__init__.py
+++ b/agentflow/core/llm/__init__.py
@@ -1,6 +1,7 @@
 """LLM client creation utilities shared across agents and evaluators."""
 
-from .anthropic_batch import AnthropicBatch, BatchResult
+from .anthropic_batch import AnthropicBatch
+from .batch_common import BatchResult
 from .caller import call_llm
 from .client_factory import (
     DEFAULT_LLM_TIMEOUT_SECONDS,
@@ -10,12 +11,14 @@ from .client_factory import (
     resolve_provider_and_model,
     set_default_llm_timeout,
 )
+from .openai_batch import OpenAIBatch
 
 
 __all__ = [
     "DEFAULT_LLM_TIMEOUT_SECONDS",
     "AnthropicBatch",
     "BatchResult",
+    "OpenAIBatch",
     "call_llm",
     "create_llm_client",
     "detect_provider",

--- a/agentflow/core/llm/__init__.py
+++ b/agentflow/core/llm/__init__.py
@@ -1,20 +1,25 @@
 """LLM client creation utilities shared across agents and evaluators."""
 
+from .anthropic_batch import AnthropicBatch, BatchResult
 from .caller import call_llm
 from .client_factory import (
     DEFAULT_LLM_TIMEOUT_SECONDS,
     create_llm_client,
     detect_provider,
     get_default_llm_timeout,
+    resolve_provider_and_model,
     set_default_llm_timeout,
 )
 
 
 __all__ = [
     "DEFAULT_LLM_TIMEOUT_SECONDS",
+    "AnthropicBatch",
+    "BatchResult",
     "call_llm",
     "create_llm_client",
     "detect_provider",
     "get_default_llm_timeout",
+    "resolve_provider_and_model",
     "set_default_llm_timeout",
 ]

--- a/agentflow/core/llm/anthropic_batch.py
+++ b/agentflow/core/llm/anthropic_batch.py
@@ -25,6 +25,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+from agentflow.core.llm.batch_common import BatchResult
 from agentflow.core.llm.client_factory import create_llm_client
 
 
@@ -36,25 +37,6 @@ DEFAULT_MAX_TOKENS = 16000
 logger = logging.getLogger("agentflow.llm.anthropic_batch")
 
 _TERMINAL_STATUS = "ended"
-
-
-@dataclass
-class BatchResult:
-    """One entry from a completed batch."""
-
-    custom_id: str
-    status: str
-    """``succeeded``, ``errored``, ``canceled``, or ``expired``."""
-    text: str = ""
-    stop_reason: str | None = None
-    input_tokens: int = 0
-    output_tokens: int = 0
-    error: Any = None
-    raw: Any = None
-
-    @property
-    def ok(self) -> bool:
-        return self.status == "succeeded"
 
 
 @dataclass

--- a/agentflow/core/llm/anthropic_batch.py
+++ b/agentflow/core/llm/anthropic_batch.py
@@ -1,0 +1,198 @@
+"""Anthropic Message Batches helper.
+
+Batches run asynchronously at reduced cost and are a poor fit for the graph
+execution model (a graph run is interactive and stateful; a batch is neither),
+so this is a standalone utility rather than an ``Agent`` method.
+
+    from agentflow.core.llm.anthropic_batch import AnthropicBatch
+
+    batch = AnthropicBatch(model="claude-haiku-4-5")
+    batch.add("row-1", [{"role": "user", "content": "Summarise: ..."}])
+    batch.add("row-2", [{"role": "user", "content": "Summarise: ..."}])
+
+    batch_id = await batch.submit()
+    results = await batch.wait(batch_id)      # keyed by custom_id
+    print(results["row-1"].text)
+
+Results arrive in **any order**, so they are keyed by ``custom_id`` throughout.
+Indexing by position is the classic way to silently mismatch a batch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from agentflow.core.llm.client_factory import create_llm_client
+
+
+# ``core.graph`` imports this package, so these are resolved lazily inside
+# ``add()`` rather than at module import time, which would be a cycle.
+DEFAULT_MAX_TOKENS = 16000
+
+
+logger = logging.getLogger("agentflow.llm.anthropic_batch")
+
+_TERMINAL_STATUS = "ended"
+
+
+@dataclass
+class BatchResult:
+    """One entry from a completed batch."""
+
+    custom_id: str
+    status: str
+    """``succeeded``, ``errored``, ``canceled``, or ``expired``."""
+    text: str = ""
+    stop_reason: str | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    error: Any = None
+    raw: Any = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "succeeded"
+
+
+@dataclass
+class AnthropicBatch:
+    """Build, submit, and collect an Anthropic message batch."""
+
+    model: str
+    max_tokens: int = DEFAULT_MAX_TOKENS
+    anthropic_backend: str | None = None
+    client: Any = None
+    requests: list[dict[str, Any]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.client is None:
+            self.client = create_llm_client("anthropic", anthropic_backend=self.anthropic_backend)
+
+    def add(
+        self,
+        custom_id: str,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[Any] | None = None,
+        **params: Any,
+    ) -> AnthropicBatch:
+        """Queue one request. ``custom_id`` is how its result is found later.
+
+        Messages use agentflow's internal dialect and go through the same
+        translation as a live call, so system prompts and tool results are
+        shaped correctly.
+        """
+        from agentflow.core.graph.agent_internal.anthropic_request import (
+            convert_tools,
+            merge_tool_results,
+            split_system,
+        )
+
+        if any(entry["custom_id"] == custom_id for entry in self.requests):
+            raise ValueError(f"Duplicate custom_id in batch: {custom_id!r}")
+
+        system, remainder = split_system(messages)
+        remainder = merge_tool_results(remainder)
+
+        body: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": params.pop("max_tokens", self.max_tokens),
+            "messages": remainder,
+            **params,
+        }
+        if system:
+            body["system"] = system
+        anthropic_tools = convert_tools(tools)
+        if anthropic_tools:
+            body["tools"] = anthropic_tools
+
+        self.requests.append({"custom_id": custom_id, "params": body})
+        return self
+
+    async def submit(self) -> str:
+        """Create the batch and return its id."""
+        if not self.requests:
+            raise ValueError("Cannot submit an empty batch; call add() first.")
+
+        batch = await self.client.messages.batches.create(requests=self.requests)
+        batch_id = getattr(batch, "id", "")
+        logger.info("Submitted Anthropic batch %s with %d requests", batch_id, len(self.requests))
+        return batch_id
+
+    async def status(self, batch_id: str) -> str:
+        """Return the batch's current ``processing_status``."""
+        batch = await self.client.messages.batches.retrieve(batch_id)
+        return getattr(batch, "processing_status", "")
+
+    async def wait(
+        self,
+        batch_id: str,
+        *,
+        poll_interval: float = 30.0,
+        timeout: float | None = None,
+    ) -> dict[str, BatchResult]:
+        """Poll until the batch ends, then return results keyed by ``custom_id``.
+
+        Args:
+            batch_id: The id returned by :meth:`submit`.
+            poll_interval: Seconds between polls. Batches are not latency
+                sensitive; polling hard just burns rate limit.
+            timeout: Give up after this many seconds. ``None`` waits forever.
+
+        Raises:
+            TimeoutError: If *timeout* elapses before the batch ends.
+        """
+        waited = 0.0
+        while True:
+            status = await self.status(batch_id)
+            if status == _TERMINAL_STATUS:
+                break
+
+            if timeout is not None and waited >= timeout:
+                raise TimeoutError(f"Batch {batch_id} still '{status}' after {waited:.0f}s.")
+
+            await asyncio.sleep(poll_interval)
+            waited += poll_interval
+
+        return await self.results(batch_id)
+
+    async def results(self, batch_id: str) -> dict[str, BatchResult]:
+        """Collect a finished batch's results, keyed by ``custom_id``."""
+        collected: dict[str, BatchResult] = {}
+
+        async for entry in await self.client.messages.batches.results(batch_id):
+            custom_id = getattr(entry, "custom_id", "")
+            result = getattr(entry, "result", None)
+            status = getattr(result, "type", "errored")
+
+            if status != "succeeded":
+                collected[custom_id] = BatchResult(
+                    custom_id=custom_id,
+                    status=status,
+                    error=getattr(result, "error", None),
+                    raw=entry,
+                )
+                continue
+
+            message = getattr(result, "message", None)
+            text = "".join(
+                getattr(block, "text", "") or ""
+                for block in getattr(message, "content", None) or []
+                if getattr(block, "type", None) == "text"
+            )
+            usage = getattr(message, "usage", None)
+            collected[custom_id] = BatchResult(
+                custom_id=custom_id,
+                status=status,
+                text=text,
+                stop_reason=getattr(message, "stop_reason", None),
+                input_tokens=getattr(usage, "input_tokens", 0) or 0,
+                output_tokens=getattr(usage, "output_tokens", 0) or 0,
+                raw=entry,
+            )
+
+        logger.info("Collected %d results for batch %s", len(collected), batch_id)
+        return collected

--- a/agentflow/core/llm/batch_common.py
+++ b/agentflow/core/llm/batch_common.py
@@ -1,0 +1,31 @@
+"""Shared types for provider batch helpers.
+
+Both batch helpers expose the same surface — ``add`` / ``submit`` / ``status`` /
+``wait`` / ``results`` — and return the same :class:`BatchResult`, so switching
+providers does not mean relearning the interface. The provider-specific parts
+(inline requests vs a JSONL upload, different status vocabularies) stay hidden.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class BatchResult:
+    """One entry from a completed batch, normalised across providers."""
+
+    custom_id: str
+    status: str
+    """``succeeded``, ``errored``, ``canceled``, or ``expired``."""
+    text: str = ""
+    stop_reason: str | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    error: Any = None
+    raw: Any = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "succeeded"

--- a/agentflow/core/llm/caller.py
+++ b/agentflow/core/llm/caller.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Literal
 
-from agentflow.core.llm.client_factory import create_llm_client, detect_provider
+from agentflow.core.llm.client_factory import create_llm_client, resolve_provider_and_model
 
 
 logger = logging.getLogger("agentflow.llm.caller")
@@ -70,8 +70,27 @@ async def call_llm(
         ``(text, input_tokens, output_tokens, cache_read_tokens)`` — plain tuple.
         Token counts are 0 when the provider does not report them.
     """
-    provider = detect_provider(model, use_vertex_ai=use_vertex_ai)
-    client = create_llm_client(provider, use_vertex_ai=use_vertex_ai)
+    # resolve_provider_and_model (not detect_provider) so a recognised
+    # ``provider/`` prefix is stripped before the name reaches the SDK. Sending
+    # "gemini/gemini-2.5-flash" or "anthropic/claude-opus-5" verbatim fails.
+    provider, model = resolve_provider_and_model(model, use_vertex_ai=use_vertex_ai)
+    client = create_llm_client(
+        provider,
+        use_vertex_ai=use_vertex_ai,
+        anthropic_backend=llm_kwargs.pop("anthropic_backend", None),
+    )
+
+    if provider == "anthropic":
+        return await _call_anthropic(
+            client,
+            model,
+            prompt,
+            system_prompt=system_prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            json_mode=json_mode,
+            **llm_kwargs,
+        )
 
     if provider == "google":
         return await _call_google(
@@ -106,6 +125,71 @@ async def call_llm(
         json_mode=json_mode,
         **llm_kwargs,
     )
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+async def _call_anthropic(
+    client: Any,
+    model: str,
+    prompt: str,
+    *,
+    system_prompt: str | None,
+    max_tokens: int,
+    temperature: float,
+    json_mode: bool,
+    **llm_kwargs: Any,
+) -> tuple[str, int, int, int]:
+    from agentflow.core.graph.agent_internal.anthropic_request import strip_bedrock_prefix
+    from agentflow.core.graph.agent_internal.constants import ANTHROPIC_NO_SAMPLING_MODELS
+
+    call_kwargs: dict[str, Any] = dict(llm_kwargs)
+    call_kwargs["max_tokens"] = max_tokens
+
+    # Current Claude models reject temperature with a 400. call_llm defaults it
+    # to 0.3 for every caller, so it has to be dropped rather than forwarded.
+    if strip_bedrock_prefix(model) not in ANTHROPIC_NO_SAMPLING_MODELS:
+        call_kwargs["temperature"] = temperature
+
+    if system_prompt:
+        call_kwargs["system"] = system_prompt
+
+    if json_mode:
+        # Anthropic has no response_mime_type; steer with an instruction, which
+        # is what the Messages API supports without a full JSON schema.
+        suffix = "\n\nRespond with valid JSON only, no prose and no code fences."
+        call_kwargs["system"] = (call_kwargs.get("system") or "") + suffix
+
+    response = await client.messages.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        **call_kwargs,
+    )
+
+    if getattr(response, "stop_reason", None) == "refusal":
+        details = getattr(response, "stop_details", None)
+        logger.warning(
+            "Anthropic refused the request (category=%s)",
+            getattr(details, "category", None),
+        )
+
+    text = ""
+    for block in getattr(response, "content", None) or []:
+        if getattr(block, "type", None) == "text":
+            text += getattr(block, "text", "") or ""
+
+    usage = getattr(response, "usage", None)
+    inp = getattr(usage, "input_tokens", 0) or 0
+    out = getattr(usage, "output_tokens", 0) or 0
+    cache = getattr(usage, "cache_read_input_tokens", 0) or 0
+
+    if cache:
+        logger.debug("Cache hit: %d cached tokens (Anthropic)", cache)
+
+    return text.strip(), inp, out, cache
 
 
 # ---------------------------------------------------------------------------

--- a/agentflow/core/llm/client_factory.py
+++ b/agentflow/core/llm/client_factory.py
@@ -85,6 +85,8 @@ _PROVIDER_PREFIXES = {
     "google": "google",
     "openai": "openai",
     "gpt": "openai",
+    "anthropic": "anthropic",
+    "claude": "anthropic",
 }
 
 # Keys allowed in the AsyncOpenAI constructor but NOT in per-request calls.
@@ -100,6 +102,40 @@ _CLIENT_CONSTRUCTOR_KWARGS = frozenset(
     }
 )
 
+# Anthropic's constructors do not accept ``organization`` / ``project``, so the
+# OpenAI-shaped allowlist above cannot be reused. ``http_client`` here must be an
+# httpx2 client: the anthropic SDK moved to httpx2 in 1.0, while the OpenAI SDK
+# still uses httpx. Passing the wrong one fails at request time.
+_ANTHROPIC_CONSTRUCTOR_KWARGS = frozenset(
+    {
+        "timeout",
+        "max_retries",
+        "default_headers",
+        "default_query",
+        "http_client",
+        "auth_token",
+        "middleware",
+    }
+)
+_ANTHROPIC_VERTEX_CONSTRUCTOR_KWARGS = _ANTHROPIC_CONSTRUCTOR_KWARGS | frozenset(
+    {
+        "region",
+        "project_id",
+        "access_token",
+        "credentials",
+    }
+)
+_ANTHROPIC_BEDROCK_CONSTRUCTOR_KWARGS = _ANTHROPIC_CONSTRUCTOR_KWARGS | frozenset(
+    {
+        "aws_access_key",
+        "aws_secret_key",
+        "aws_session_token",
+        "aws_region",
+        "aws_profile",
+        "api_key",
+    }
+)
+
 
 def detect_provider(model: str, use_vertex_ai: bool = False) -> str:
     """Infer the provider from a model name.
@@ -107,20 +143,29 @@ def detect_provider(model: str, use_vertex_ai: bool = False) -> str:
     Args:
         model: Model identifier, optionally prefixed with ``"provider/"``
             (e.g. ``"gemini/gemini-2.5-flash"``, ``"openai/gpt-4o"``).
-        use_vertex_ai: When True, always returns ``"google"`` regardless of model.
+        use_vertex_ai: When True, selects ``"google"`` unless the model is
+            clearly a Claude model. Claude runs on Vertex too, so the flag acts
+            as a backend selector there rather than a provider override.
 
     Returns:
-        One of ``"google"`` or ``"openai"``.
+        One of ``"google"``, ``"openai"``, or ``"anthropic"``.
     """
-    if use_vertex_ai:
-        return "google"
-
     if "/" in model:
         prefix = model.split("/", 1)[0].lower()
         if prefix in _PROVIDER_PREFIXES:
             return _PROVIDER_PREFIXES[prefix]
         # Unknown prefix — fall through to name-based detection using the suffix
         model = model.split("/", 1)[1]
+
+    # Checked before the use_vertex_ai short-circuit: Claude runs on Vertex too,
+    # and use_vertex_ai is the flag a caller naturally reaches for. Letting the
+    # flag force "google" here would build a Google client for a Claude model and
+    # fail at request time with a confusing error.
+    if model.lower().startswith(("claude-", "anthropic.")):
+        return "anthropic"
+
+    if use_vertex_ai:
+        return "google"
 
     lower = model.lower()
     if lower.startswith(("gemini-", "imagen-", "veo-", "chirp")):
@@ -148,11 +193,12 @@ def resolve_provider_and_model(model: str, use_vertex_ai: bool = False) -> tuple
 
     Args:
         model: Model identifier, optionally prefixed with ``"provider/"``.
-        use_vertex_ai: When True, always selects the ``"google"`` provider.
+        use_vertex_ai: When True, selects ``"google"`` unless the model is
+            clearly a Claude model (see :func:`detect_provider`).
 
     Returns:
-        A ``(provider, model)`` tuple where provider is ``"google"`` or
-        ``"openai"``.
+        A ``(provider, model)`` tuple where provider is ``"google"``,
+        ``"openai"``, or ``"anthropic"``.
     """
     if "/" in model:
         prefix, rest = model.split("/", 1)
@@ -168,16 +214,20 @@ def create_llm_client(
     use_vertex_ai: bool = False,
     base_url: str | None = None,
     api_key: str | None = None,
+    anthropic_backend: str | None = None,
     **extra_kwargs: Any,
 ) -> Any:
     """Create a native async SDK client for the given provider.
 
     Args:
-        provider: ``"google"`` or ``"openai"``.
+        provider: ``"google"``, ``"openai"``, or ``"anthropic"``.
         use_vertex_ai: When True and provider is ``"google"``, creates a
             Vertex AI client using ``GOOGLE_CLOUD_PROJECT`` / ``GOOGLE_CLOUD_LOCATION``.
+            Google-specific; use ``anthropic_backend`` for Anthropic on Vertex.
         base_url: Custom base URL for OpenAI-compatible APIs (ollama, vllm, …).
         api_key: Explicit API key. Falls back to env vars when omitted.
+        anthropic_backend: Backend selector for the Anthropic provider.
+            ``None`` (direct Claude API), ``"vertex"``, or ``"bedrock"``.
         **extra_kwargs: Forwarded to the AsyncOpenAI constructor
             (only recognised constructor keys are passed through).
 
@@ -198,7 +248,17 @@ def create_llm_client(
             **extra_kwargs,
         )
 
-    raise ValueError(f"Unsupported provider: '{provider}'. Supported: 'google', 'openai'.")
+    if provider == "anthropic":
+        return _create_anthropic_client(
+            base_url=base_url,
+            api_key=api_key,
+            anthropic_backend=anthropic_backend,
+            **extra_kwargs,
+        )
+
+    raise ValueError(
+        f"Unsupported provider: '{provider}'. Supported: 'google', 'openai', 'anthropic'."
+    )
 
 
 def _create_google_client(*, use_vertex_ai: bool) -> Any:
@@ -271,3 +331,103 @@ def _create_openai_client(
         return AsyncOpenAI(api_key=resolved_key, base_url=base_url, **client_kwargs)
 
     return AsyncOpenAI(api_key=resolved_key, **client_kwargs)
+
+
+def _create_anthropic_client(
+    *,
+    base_url: str | None,
+    api_key: str | None,
+    anthropic_backend: str | None = None,
+    **extra_kwargs: Any,
+) -> Any:
+    """Create an async Anthropic client for the selected backend.
+
+    Anthropic reaches three distinct backends, so unlike Google's boolean
+    ``use_vertex_ai`` flag the selector is a string:
+
+    * ``None``      -> ``AsyncAnthropic``              (direct Claude API)
+    * ``"vertex"``  -> ``AsyncAnthropicVertex``        (Google Cloud Vertex AI)
+    * ``"bedrock"`` -> ``AsyncAnthropicBedrockMantle`` (Amazon Bedrock)
+
+    ``AsyncAnthropicBedrockMantle`` is the Messages-API Bedrock endpoint. The
+    plain ``AsyncAnthropicBedrock`` client is the legacy ``InvokeModel`` path and
+    is deliberately not used here.
+
+    Region, project, and AWS credentials are resolved by the SDK from the
+    environment unless passed explicitly through ``llm_kwargs``.
+    """
+    backend = (anthropic_backend or "").lower() or None
+
+    if backend not in (None, "vertex", "bedrock"):
+        raise ValueError(
+            f"Unsupported anthropic_backend: '{anthropic_backend}'. "
+            "Supported: None (direct API), 'vertex', 'bedrock'."
+        )
+
+    if backend == "vertex":
+        try:
+            from anthropic import AsyncAnthropicVertex
+        except ImportError as exc:
+            raise ImportError(
+                "anthropic SDK with Vertex support is required for "
+                "anthropic_backend='vertex'. Install it with: "
+                'pip install "10xscale-agentflow[anthropic-vertex]"'
+            ) from exc
+
+        client_kwargs = {
+            k: v for k, v in extra_kwargs.items() if k in _ANTHROPIC_VERTEX_CONSTRUCTOR_KWARGS
+        }
+        client_kwargs.setdefault("timeout", get_default_llm_timeout())
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        logger.info("Creating Anthropic client (Vertex AI)")
+        return AsyncAnthropicVertex(**client_kwargs)
+
+    if backend == "bedrock":
+        try:
+            from anthropic import AsyncAnthropicBedrockMantle
+        except ImportError as exc:
+            raise ImportError(
+                "anthropic SDK with Bedrock support is required for "
+                "anthropic_backend='bedrock'. Install it with: "
+                'pip install "10xscale-agentflow[anthropic-bedrock]"'
+            ) from exc
+
+        client_kwargs = {
+            k: v for k, v in extra_kwargs.items() if k in _ANTHROPIC_BEDROCK_CONSTRUCTOR_KWARGS
+        }
+        client_kwargs.setdefault("timeout", get_default_llm_timeout())
+        if api_key and "api_key" not in client_kwargs:
+            client_kwargs["api_key"] = api_key
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        logger.info("Creating Anthropic client (Bedrock Mantle)")
+        return AsyncAnthropicBedrockMantle(**client_kwargs)
+
+    try:
+        from anthropic import AsyncAnthropic
+    except ImportError as exc:
+        raise ImportError(
+            "anthropic SDK is required for the Anthropic provider. "
+            'Install it with: pip install "10xscale-agentflow[anthropic]"'
+        ) from exc
+
+    resolved_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+    if not resolved_key:
+        # Not fatal: the SDK also resolves ANTHROPIC_AUTH_TOKEN, an `ant auth
+        # login` profile, or Workload Identity Federation. An unset API key does
+        # not mean there are no credentials.
+        logger.info(
+            "ANTHROPIC_API_KEY not set. Falling back to the SDK's own credential "
+            "resolution (ANTHROPIC_AUTH_TOKEN, auth profile, or federation)."
+        )
+
+    client_kwargs = {k: v for k, v in extra_kwargs.items() if k in _ANTHROPIC_CONSTRUCTOR_KWARGS}
+    client_kwargs.setdefault("timeout", get_default_llm_timeout())
+    if resolved_key:
+        client_kwargs["api_key"] = resolved_key
+    if base_url:
+        logger.info("Creating Anthropic client with custom base_url: %s", base_url)
+        client_kwargs["base_url"] = base_url
+
+    return AsyncAnthropic(**client_kwargs)

--- a/agentflow/core/llm/openai_batch.py
+++ b/agentflow/core/llm/openai_batch.py
@@ -1,0 +1,220 @@
+"""OpenAI Message Batches helper.
+
+Same surface as :class:`~agentflow.core.llm.anthropic_batch.AnthropicBatch`, so
+switching providers does not mean relearning the interface:
+
+    from agentflow.core.llm import OpenAIBatch
+
+    batch = OpenAIBatch(model="gpt-4o-mini")
+    batch.add("row-1", [{"role": "user", "content": "Summarise: ..."}])
+    batch.add("row-2", [{"role": "user", "content": "Summarise: ..."}])
+
+    batch_id = await batch.submit()
+    results = await batch.wait(batch_id)      # keyed by custom_id
+    print(results["row-1"].text)
+
+The mechanics underneath differ from Anthropic's: OpenAI takes a JSONL **file**
+of requests rather than an inline list, so ``submit()`` uploads one first and
+``results()`` downloads and parses the output file. That is deliberately hidden.
+
+Results are keyed by ``custom_id`` throughout, because batch results arrive in
+any order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from agentflow.core.llm.batch_common import BatchResult
+from agentflow.core.llm.client_factory import create_llm_client
+
+
+logger = logging.getLogger("agentflow.llm.openai_batch")
+
+# OpenAI batch statuses that mean "no further progress will happen".
+_TERMINAL_STATUSES = frozenset({"completed", "failed", "expired", "cancelled"})
+
+# Maps OpenAI's terminal batch statuses onto the shared result vocabulary.
+_STATUS_ALIASES = {"cancelled": "canceled", "failed": "errored"}
+
+DEFAULT_COMPLETION_WINDOW = "24h"
+CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions"
+
+# Per-request HTTP status at or above which the entry counts as failed.
+_HTTP_ERROR_FLOOR = 400
+
+
+@dataclass
+class OpenAIBatch:
+    """Build, submit, and collect an OpenAI batch."""
+
+    model: str
+    completion_window: str = DEFAULT_COMPLETION_WINDOW
+    endpoint: str = CHAT_COMPLETIONS_ENDPOINT
+    client: Any = None
+    requests: list[dict[str, Any]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.client is None:
+            self.client = create_llm_client("openai")
+
+    def add(
+        self,
+        custom_id: str,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[Any] | None = None,
+        **params: Any,
+    ) -> OpenAIBatch:
+        """Queue one request. ``custom_id`` is how its result is found later.
+
+        Messages are already in agentflow's internal (OpenAI-shaped) dialect, so
+        unlike the Anthropic helper no translation is needed here.
+        """
+        if any(entry["custom_id"] == custom_id for entry in self.requests):
+            raise ValueError(f"Duplicate custom_id in batch: {custom_id!r}")
+
+        body: dict[str, Any] = {"model": self.model, "messages": messages, **params}
+        if tools:
+            body["tools"] = tools
+
+        self.requests.append(
+            {
+                "custom_id": custom_id,
+                "method": "POST",
+                "url": self.endpoint,
+                "body": body,
+            }
+        )
+        return self
+
+    def _to_jsonl(self) -> bytes:
+        """Render the queued requests as the JSONL payload OpenAI expects."""
+        return "\n".join(json.dumps(entry) for entry in self.requests).encode("utf-8")
+
+    async def submit(self) -> str:
+        """Upload the request file, create the batch, and return its id."""
+        if not self.requests:
+            raise ValueError("Cannot submit an empty batch; call add() first.")
+
+        upload = io.BytesIO(self._to_jsonl())
+        upload.name = "batch_requests.jsonl"
+
+        uploaded = await self.client.files.create(file=upload, purpose="batch")
+        batch = await self.client.batches.create(
+            input_file_id=getattr(uploaded, "id", ""),
+            endpoint=self.endpoint,
+            completion_window=self.completion_window,
+        )
+        batch_id = getattr(batch, "id", "")
+        logger.info("Submitted OpenAI batch %s with %d requests", batch_id, len(self.requests))
+        return batch_id
+
+    async def status(self, batch_id: str) -> str:
+        """Return the batch's current status."""
+        batch = await self.client.batches.retrieve(batch_id)
+        return getattr(batch, "status", "")
+
+    async def wait(
+        self,
+        batch_id: str,
+        *,
+        poll_interval: float = 30.0,
+        timeout: float | None = None,
+    ) -> dict[str, BatchResult]:
+        """Poll until the batch reaches a terminal status, then return results.
+
+        Args:
+            batch_id: The id returned by :meth:`submit`.
+            poll_interval: Seconds between polls. Batches are not latency
+                sensitive; polling hard just burns rate limit.
+            timeout: Give up after this many seconds. ``None`` waits forever.
+
+        Raises:
+            TimeoutError: If *timeout* elapses before the batch finishes.
+        """
+        waited = 0.0
+        while True:
+            status = await self.status(batch_id)
+            if status in _TERMINAL_STATUSES:
+                break
+
+            if timeout is not None and waited >= timeout:
+                raise TimeoutError(f"Batch {batch_id} still '{status}' after {waited:.0f}s.")
+
+            await asyncio.sleep(poll_interval)
+            waited += poll_interval
+
+        return await self.results(batch_id)
+
+    async def results(self, batch_id: str) -> dict[str, BatchResult]:
+        """Download and parse a finished batch's output, keyed by ``custom_id``."""
+        batch = await self.client.batches.retrieve(batch_id)
+        output_file_id = getattr(batch, "output_file_id", None)
+
+        if not output_file_id:
+            status = getattr(batch, "status", "unknown")
+            logger.warning(
+                "OpenAI batch %s has no output file (status=%s); nothing to collect.",
+                batch_id,
+                status,
+            )
+            return {}
+
+        content = await self.client.files.content(output_file_id)
+        raw = getattr(content, "text", None)
+        if raw is None:
+            body = await content.aread() if hasattr(content, "aread") else content.read()
+            raw = body.decode("utf-8") if isinstance(body, bytes) else str(body)
+
+        collected: dict[str, BatchResult] = {}
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            entry = json.loads(line)
+            result = _parse_line(entry)
+            collected[result.custom_id] = result
+
+        logger.info("Collected %d results for batch %s", len(collected), batch_id)
+        return collected
+
+
+def _parse_line(entry: dict[str, Any]) -> BatchResult:
+    """Turn one output-file JSONL line into a :class:`BatchResult`."""
+    custom_id = entry.get("custom_id", "")
+    error = entry.get("error")
+    response = entry.get("response") or {}
+    status_code = response.get("status_code")
+
+    if error or (status_code is not None and status_code >= _HTTP_ERROR_FLOOR):
+        return BatchResult(
+            custom_id=custom_id,
+            status="errored",
+            error=error or response.get("body"),
+            raw=entry,
+        )
+
+    body = response.get("body") or {}
+    choices = body.get("choices") or []
+    message = choices[0].get("message", {}) if choices else {}
+    usage = body.get("usage") or {}
+
+    return BatchResult(
+        custom_id=custom_id,
+        status="succeeded",
+        text=message.get("content") or "",
+        stop_reason=choices[0].get("finish_reason") if choices else None,
+        input_tokens=usage.get("prompt_tokens", 0) or 0,
+        output_tokens=usage.get("completion_tokens", 0) or 0,
+        raw=entry,
+    )
+
+
+def normalise_status(status: str) -> str:
+    """Map an OpenAI terminal status onto the shared result vocabulary."""
+    return _STATUS_ALIASES.get(status, status)

--- a/agentflow/runtime/adapters/llm/__init__.py
+++ b/agentflow/runtime/adapters/llm/__init__.py
@@ -3,6 +3,7 @@
 This package exposes the concrete response converters used by Agentflow.
 """
 
+from .anthropic_converter import AnthropicConverter
 from .base_converter import BaseConverter, ConverterType
 from .google_genai_converter import GoogleGenAIConverter
 from .openai_converter import OpenAIConverter
@@ -10,6 +11,7 @@ from .openai_responses_converter import OpenAIResponsesConverter
 
 
 __all__ = [
+    "AnthropicConverter",
     "BaseConverter",
     "ConverterType",
     "GoogleGenAIConverter",

--- a/agentflow/runtime/adapters/llm/anthropic_converter.py
+++ b/agentflow/runtime/adapters/llm/anthropic_converter.py
@@ -1,0 +1,444 @@
+"""Convert Anthropic Messages API responses into agentflow messages."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncGenerator
+from datetime import datetime
+from typing import Any
+
+from agentflow.core.state.message import (
+    Message,
+    TokenUsages,
+    generate_id,
+)
+from agentflow.core.state.message_block import (
+    ReasoningBlock,
+    TextBlock,
+    ToolCallBlock,
+)
+
+from .base_converter import BaseConverter
+
+
+logger = logging.getLogger("agentflow.adapters.anthropic")
+
+# A refusal is a successful HTTP 200 whose content may be empty or partial.
+_REFUSAL = "refusal"
+
+# Result block types the server tools emit. Defined here rather than imported
+# from the request-side builders in ``core.graph``: this package is imported
+# *by* ``core.graph``, so reaching back into it would be a circular import.
+# Response block types are a converter concern anyway.
+SERVER_TOOL_RESULT_TYPES = frozenset(
+    {
+        "web_search_tool_result",
+        "web_fetch_tool_result",
+        "bash_code_execution_tool_result",
+        "code_execution_tool_result",
+        "tool_search_tool_result",
+    }
+)
+
+
+def _server_result_payload(block: Any) -> dict[str, Any]:
+    """Normalise a server-tool result block into a plain dict.
+
+    Web search returns a *list* of results on success but a single error
+    *object* on failure, and neither raises: a server-tool error arrives as a
+    normal HTTP 200. Branch on that shape before treating it as results.
+    """
+    content = getattr(block, "content", None)
+    payload: dict[str, Any] = {
+        "type": getattr(block, "type", ""),
+        "tool_use_id": getattr(block, "tool_use_id", ""),
+    }
+
+    if isinstance(content, list):
+        payload["results"] = [
+            item.model_dump() if hasattr(item, "model_dump") else item for item in content
+        ]
+    elif content is not None:
+        payload["result"] = content.model_dump() if hasattr(content, "model_dump") else content
+        error_code = getattr(content, "error_code", None)
+        if error_code:
+            payload["error_code"] = error_code
+            logger.warning(
+                "Anthropic server tool %s failed: %s",
+                payload["type"],
+                error_code,
+            )
+
+    return payload
+
+
+class AnthropicConverter(BaseConverter):
+    """Convert Anthropic responses and stream events into agentflow messages."""
+
+    async def convert_response(self, response: Any) -> Message:
+        """Convert a non-streaming Anthropic Message into an agentflow Message.
+
+        ``stop_reason`` is checked before ``content`` is read: on a refusal the
+        request succeeded at the HTTP layer but ``content`` may be empty, so
+        indexing into it would raise on an otherwise valid response.
+        """
+        usages = self._extract_usage(response)
+        stop_reason = getattr(response, "stop_reason", None)
+        model = getattr(response, "model", "")
+        response_id = getattr(response, "id", None)
+
+        metadata: dict[str, Any] = {
+            "provider": "anthropic",
+            "model": model,
+            "finish_reason": stop_reason or "UNKNOWN",
+        }
+
+        if stop_reason == _REFUSAL:
+            return self._build_refusal_message(response, usages, metadata)
+
+        blocks: list[Any] = []
+        tool_calls: list[dict[str, Any]] = []
+        server_results: list[dict[str, Any]] = []
+        reasoning_text = ""
+
+        for block in getattr(response, "content", None) or []:
+            btype = getattr(block, "type", None)
+
+            if btype == "text":
+                blocks.append(TextBlock(text=getattr(block, "text", "")))
+
+            elif btype == "thinking":
+                thinking = getattr(block, "thinking", "") or ""
+                if thinking:
+                    reasoning_text += thinking
+                    blocks.append(ReasoningBlock(summary=thinking))
+
+            elif btype == "tool_use":
+                args = getattr(block, "input", None) or {}
+                if not isinstance(args, dict):
+                    args = {}
+                call_id = getattr(block, "id", "")
+                name = getattr(block, "name", "")
+                blocks.append(ToolCallBlock(id=call_id, name=name, args=args))
+                tool_calls.append(
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": name, "arguments": json.dumps(args)},
+                    }
+                )
+
+            elif btype == "server_tool_use":
+                # Anthropic ran this itself; it is a record of what happened, not
+                # a call for agentflow's ToolNode to execute. Never added to
+                # tools_calls, or the graph would try to run it again.
+                args = getattr(block, "input", None) or {}
+                blocks.append(
+                    ToolCallBlock(
+                        id=getattr(block, "id", ""),
+                        name=getattr(block, "name", ""),
+                        args=args if isinstance(args, dict) else {},
+                        tool_type="server_tool",
+                    )
+                )
+
+            elif btype in SERVER_TOOL_RESULT_TYPES:
+                server_results.append(_server_result_payload(block))
+
+        if server_results:
+            metadata["server_tool_results"] = server_results
+
+        if stop_reason == "pause_turn":
+            # Server-tool iteration limit. The turn is resumable by re-sending
+            # the conversation with this response appended.
+            metadata["pause_turn"] = True
+            logger.info(
+                "Anthropic paused the turn at a server-tool iteration limit; "
+                "re-send the conversation including this response to resume."
+            )
+
+        logger.debug("Creating message from Anthropic response with id: %s", response_id)
+
+        return Message(
+            message_id=generate_id(response_id),
+            role=getattr(response, "role", "assistant") or "assistant",
+            content=blocks,
+            reasoning=reasoning_text or None,
+            timestamp=datetime.now().timestamp(),
+            metadata=metadata,
+            usages=usages,
+            raw=response.model_dump() if hasattr(response, "model_dump") else {},
+            tools_calls=tool_calls or None,
+        )
+
+    @staticmethod
+    def _build_refusal_message(
+        response: Any,
+        usages: TokenUsages,
+        metadata: dict[str, Any],
+    ) -> Message:
+        """Build a message for a policy refusal.
+
+        ``stop_details`` is populated only when ``stop_reason == "refusal"``, so
+        it is read only here.
+        """
+        details = getattr(response, "stop_details", None)
+        category = getattr(details, "category", None)
+        explanation = getattr(details, "explanation", None)
+
+        metadata["refusal"] = True
+        metadata["refusal_category"] = category
+        metadata["refusal_explanation"] = explanation
+
+        logger.warning(
+            "Anthropic refused the request (category=%s): %s",
+            category,
+            explanation,
+        )
+
+        text = explanation or "The model declined to respond to this request."
+        return Message(
+            message_id=generate_id(getattr(response, "id", None)),
+            role="assistant",
+            content=[TextBlock(text=text)],
+            timestamp=datetime.now().timestamp(),
+            metadata=metadata,
+            usages=usages,
+            raw=response.model_dump() if hasattr(response, "model_dump") else {},
+        )
+
+    @staticmethod
+    def _extract_usage(response: Any) -> TokenUsages:
+        """Map Anthropic usage onto agentflow's token fields."""
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            return TokenUsages(
+                completion_tokens=0,
+                prompt_tokens=0,
+                total_tokens=0,
+                reasoning_tokens=0,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+            )
+
+        prompt = getattr(usage, "input_tokens", 0) or 0
+        completion = getattr(usage, "output_tokens", 0) or 0
+        return TokenUsages(
+            completion_tokens=completion,
+            prompt_tokens=prompt,
+            total_tokens=prompt + completion,
+            reasoning_tokens=0,
+            cache_creation_input_tokens=getattr(usage, "cache_creation_input_tokens", 0) or 0,
+            cache_read_input_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
+        )
+
+    async def convert_streaming_response(  # type: ignore[override]
+        self,
+        config: dict,
+        node_name: str,
+        response: Any,
+        meta: dict | None = None,
+    ) -> AsyncGenerator[Message]:
+        """Convert an Anthropic stream into incremental and final Messages."""
+        async for message in self._handle_stream(config or {}, node_name or "", response, meta):
+            yield message
+
+    async def _handle_stream(  # noqa: PLR0912, PLR0915
+        self,
+        config: dict,
+        node_name: str,
+        stream: Any,
+        meta: dict | None = None,
+    ) -> AsyncGenerator[Message]:
+        """Consume the SDK event stream and emit chunk plus final messages.
+
+        ``input_json_delta`` fragments are accumulated per content-block index and
+        only parsed at ``content_block_stop``: a partial fragment is not valid
+        JSON, so emitting a tool call mid-block would produce garbage arguments.
+        """
+        accumulated_text = ""
+        accumulated_reasoning = ""
+        # block index -> {"id", "name", "json"}
+        tool_blocks: dict[int, dict[str, Any]] = {}
+        tool_calls: list[dict[str, Any]] = []
+        stop_reason: str | None = None
+        refusal_details: Any = None
+        model = ""
+        response_id: str | None = None
+        usage_obj: Any = None
+
+        metadata: dict[str, Any] = dict(meta or {})
+        metadata["provider"] = "anthropic"
+        metadata["node_name"] = node_name
+        metadata["thread_id"] = config.get("thread_id")
+
+        # ``messages.stream()`` returns a context manager; ``client.messages.create
+        # (stream=True)`` returns a bare async iterator. Support both.
+        manager = stream
+        if hasattr(stream, "__aenter__"):
+            stream = await stream.__aenter__()
+
+        try:
+            async for event in stream:
+                etype = getattr(event, "type", None)
+
+                if etype == "message_start":
+                    message_obj = getattr(event, "message", None)
+                    response_id = getattr(message_obj, "id", None)
+                    model = getattr(message_obj, "model", "") or ""
+                    usage_obj = getattr(message_obj, "usage", None)
+
+                elif etype == "content_block_start":
+                    block = getattr(event, "content_block", None)
+                    if getattr(block, "type", None) == "tool_use":
+                        tool_blocks[getattr(event, "index", 0)] = {
+                            "id": getattr(block, "id", ""),
+                            "name": getattr(block, "name", ""),
+                            "json": "",
+                        }
+
+                elif etype == "content_block_delta":
+                    delta = getattr(event, "delta", None)
+                    dtype = getattr(delta, "type", None)
+
+                    if dtype == "text_delta":
+                        piece = getattr(delta, "text", "") or ""
+                        accumulated_text += piece
+                        if piece:
+                            yield self._chunk_message(
+                                [TextBlock(text=piece)], metadata, response_id
+                            )
+
+                    elif dtype == "thinking_delta":
+                        piece = getattr(delta, "thinking", "") or ""
+                        accumulated_reasoning += piece
+                        if piece:
+                            yield self._chunk_message(
+                                [ReasoningBlock(summary=piece)], metadata, response_id
+                            )
+
+                    elif dtype == "input_json_delta":
+                        index = getattr(event, "index", 0)
+                        if index in tool_blocks:
+                            tool_blocks[index]["json"] += getattr(delta, "partial_json", "") or ""
+
+                elif etype == "content_block_stop":
+                    index = getattr(event, "index", 0)
+                    entry = tool_blocks.pop(index, None)
+                    if entry is not None:
+                        tool_calls.append(self._finalise_tool_call(entry))
+
+                elif etype == "message_delta":
+                    delta = getattr(event, "delta", None)
+                    stop_reason = getattr(delta, "stop_reason", None) or stop_reason
+                    refusal_details = getattr(delta, "stop_details", None) or refusal_details
+                    usage_obj = getattr(event, "usage", None) or usage_obj
+
+        except Exception as exc:
+            logger.error("Anthropic stream error: %s", exc)
+            raise
+        finally:
+            if hasattr(manager, "__aexit__"):
+                await manager.__aexit__(None, None, None)
+
+        metadata["model"] = model
+        metadata["finish_reason"] = stop_reason or "UNKNOWN"
+
+        if stop_reason == _REFUSAL:
+            metadata["refusal"] = True
+            metadata["refusal_category"] = getattr(refusal_details, "category", None)
+            metadata["refusal_explanation"] = getattr(refusal_details, "explanation", None)
+            logger.warning(
+                "Anthropic refused mid-stream (category=%s)",
+                metadata["refusal_category"],
+            )
+
+        blocks: list[Any] = []
+        if accumulated_text:
+            blocks.append(TextBlock(text=accumulated_text))
+        if accumulated_reasoning:
+            blocks.append(ReasoningBlock(summary=accumulated_reasoning))
+        for call in tool_calls:
+            function = call["function"]
+            try:
+                args = json.loads(function["arguments"])
+            except (TypeError, ValueError):
+                args = {}
+            blocks.append(ToolCallBlock(id=call["id"], name=function["name"], args=args))
+
+        logger.debug(
+            "Stream complete - text=%d chars, reasoning=%d chars, tool_calls=%d",
+            len(accumulated_text),
+            len(accumulated_reasoning),
+            len(tool_calls),
+        )
+
+        yield Message(
+            message_id=generate_id(response_id),
+            role="assistant",
+            content=blocks,
+            delta=False,
+            reasoning=accumulated_reasoning or None,
+            timestamp=datetime.now().timestamp(),
+            metadata=metadata,
+            usages=self._usage_from_obj(usage_obj),
+            tools_calls=tool_calls or None,
+        )
+
+    @staticmethod
+    def _finalise_tool_call(entry: dict[str, Any]) -> dict[str, Any]:
+        """Turn an accumulated tool_use block into an OpenAI-shaped tool call."""
+        raw_json = entry["json"] or "{}"
+        try:
+            json.loads(raw_json)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Accumulated tool input for %s was not valid JSON; using {}.",
+                entry.get("name", ""),
+            )
+            raw_json = "{}"
+
+        return {
+            "id": entry["id"],
+            "type": "function",
+            "function": {"name": entry["name"], "arguments": raw_json},
+        }
+
+    @staticmethod
+    def _chunk_message(
+        blocks: list[Any],
+        metadata: dict[str, Any],
+        response_id: str | None,
+    ) -> Message:
+        """Build an incremental (delta) message for a stream chunk."""
+        return Message(
+            message_id=generate_id(response_id),
+            role="assistant",
+            content=blocks,
+            delta=True,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _usage_from_obj(usage: Any) -> TokenUsages:
+        """Build TokenUsages from a raw usage object (or zeros when absent)."""
+        if usage is None:
+            return TokenUsages(
+                completion_tokens=0,
+                prompt_tokens=0,
+                total_tokens=0,
+                reasoning_tokens=0,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+            )
+        prompt = getattr(usage, "input_tokens", 0) or 0
+        completion = getattr(usage, "output_tokens", 0) or 0
+        return TokenUsages(
+            completion_tokens=completion,
+            prompt_tokens=prompt,
+            total_tokens=prompt + completion,
+            reasoning_tokens=0,
+            cache_creation_input_tokens=getattr(usage, "cache_creation_input_tokens", 0) or 0,
+            cache_read_input_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
+        )

--- a/agentflow/runtime/adapters/llm/model_response_converter.py
+++ b/agentflow/runtime/adapters/llm/model_response_converter.py
@@ -60,11 +60,17 @@ class ModelResponseConverter:
                 self.converter = GoogleGenAIConverter()
                 logger.debug("Using GoogleGenAIConverter for response conversion")
 
+            elif converter == "anthropic":
+                from .anthropic_converter import AnthropicConverter
+
+                self.converter = AnthropicConverter()
+                logger.debug("Using AnthropicConverter for response conversion")
+
             else:
                 logger.error(f"Unsupported converter: {converter}")
                 raise ValueError(
                     f"Unsupported converter: {converter}. "
-                    "Supported: 'openai', 'openai_responses', 'google'"
+                    "Supported: 'openai', 'openai_responses', 'google', 'anthropic'"
                 )
 
         elif isinstance(converter, BaseConverter):

--- a/examples/providers/anthropic_react_sync.py
+++ b/examples/providers/anthropic_react_sync.py
@@ -1,0 +1,94 @@
+"""Anthropic provider example using a ReAct agent with tools.
+
+Prerequisites:
+    1. Install the extra:  pip install "10xscale-agentflow[anthropic]"
+    2. An Anthropic API key from https://console.anthropic.com.
+    3. Environment variables (set in .env or shell):
+        ANTHROPIC_API_KEY=<your-api-key>
+
+    An unset ANTHROPIC_API_KEY does not necessarily mean there are no
+    credentials: the SDK also resolves ANTHROPIC_AUTH_TOKEN, an `ant auth login`
+    profile, and Workload Identity Federation.
+
+Other backends
+--------------
+Anthropic reaches three backends, selected with ``anthropic_backend``:
+
+    Agent(model="claude-opus-5")                                # direct API
+    Agent(model="claude-opus-5", anthropic_backend="vertex")     # Vertex AI
+    Agent(model="anthropic.claude-opus-5",                       # Bedrock
+          anthropic_backend="bedrock")
+
+Vertex takes the bare model id; Bedrock ids keep their ``anthropic.`` prefix.
+Install the matching extra (``anthropic-vertex`` / ``anthropic-bedrock``).
+"""
+
+from dotenv import load_dotenv
+
+from agentflow.core import Agent, StateGraph, ToolNode
+from agentflow.core.state import AgentState, Message
+from agentflow.storage.checkpointer import InMemoryCheckpointer
+from agentflow.utils.constants import END
+
+
+load_dotenv()
+
+checkpointer = InMemoryCheckpointer()
+
+
+def get_weather(location: str) -> str:
+    """Get the current weather for a specific location."""
+    return f"The weather in {location} is sunny"
+
+
+tool_node = ToolNode([get_weather])
+
+agent = Agent(
+    model="claude-opus-5",
+    system_prompt=[{"role": "system", "content": "You are a helpful assistant."}],
+    trim_context=True,
+    # Maps to thinking={"type": "adaptive"} + output_config={"effort": "high"}.
+    # budget_tokens is never sent: it returns a 400 on current Claude models.
+    reasoning_config={"effort": "high"},
+    tool_node=tool_node,
+)
+
+
+def should_use_tools(state: AgentState) -> str:
+    """Determine if we should use tools or end the conversation."""
+    if not state.context or len(state.context) == 0:
+        return "TOOL"
+
+    last_message = state.context[-1]
+
+    if (
+        hasattr(last_message, "tools_calls")
+        and last_message.tools_calls
+        and len(last_message.tools_calls) > 0
+        and last_message.role == "assistant"
+    ):
+        return "TOOL"
+
+    if last_message.role == "tool":
+        return "MAIN"
+
+    return END
+
+
+graph = StateGraph()
+graph.add_node("MAIN", agent)
+graph.add_node("TOOL", tool_node)
+graph.add_conditional_edges("MAIN", should_use_tools, {"TOOL": "TOOL", END: END})
+graph.add_edge("TOOL", "MAIN")
+graph.set_entry_point("MAIN")
+
+app = graph.compile(checkpointer=checkpointer)
+
+if __name__ == "__main__":
+    inp = {"messages": [Message.text_message("What is the weather in New York City?")]}
+    config = {"thread_id": "12345", "recursion_limit": 10}
+
+    res = app.invoke(inp, config=config)
+
+    for msg in res["messages"]:
+        print(f"[{msg.role}] {msg}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,11 @@ build-backend = "setuptools.build_meta"
 google-genai = ["google-genai>=1.56.0"]
 realtime = ["google-genai>=1.56.0"]
 openai = ["openai>=1.77.0"]
+# Capped at <2: the SDK went 0.x -> 1.0.0 (httpx2, awaited async raw responses),
+# so an uncapped lower bound would pull a future major automatically.
+anthropic = ["anthropic>=1.0.0,<2"]
+anthropic-vertex = ["anthropic[vertex]>=1.0.0,<2"]
+anthropic-bedrock = ["anthropic[bedrock]>=1.0.0,<2"]
 pg_checkpoint = ["asyncpg>=0.29.0","redis>=4.2"]
 sqlite_checkpoint = ["aiosqlite>=0.19.0"]
 mcp = ["fastmcp>=2.11.3","mcp>=1.13.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,19 @@ all_publishers = [
     "aio-pika>=9.0.0",
 ]
 
+# Every other extra at once, for development and CI. The two Claude cloud
+# backends cost nothing to include: google-genai already pulls google-auth and
+# cloud-storage pulls boto3, so the resolved set is identical with or without
+# them. Verified with `uv pip compile --extra all`.
+all = [
+    "10xscale-agentflow[google-genai,openai,realtime,mcp]",
+    "10xscale-agentflow[anthropic,anthropic-vertex,anthropic-bedrock]",
+    "10xscale-agentflow[pg_checkpoint,sqlite_checkpoint]",
+    "10xscale-agentflow[qdrant,mem0]",
+    "10xscale-agentflow[all_publishers,observability]",
+    "10xscale-agentflow[images,cloud-storage,a2a_sdk]",
+]
+
 [tool.setuptools.packages.find]
 include = ["agentflow*"]
 exclude = ["normal_tests*", "tests*", "examples*", "docs*"]

--- a/tests/adapters/test_anthropic_converter.py
+++ b/tests/adapters/test_anthropic_converter.py
@@ -1,0 +1,372 @@
+"""Tests for the Anthropic response converter.
+
+Responses and stream events are built as lightweight stand-ins rather than real
+SDK objects: the converter reads them purely by attribute, so this keeps the
+tests independent of the installed SDK version.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentflow.runtime.adapters.llm.anthropic_converter import AnthropicConverter
+
+
+def _usage(**overrides):
+    base = {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _response(content, *, stop_reason="end_turn", **overrides):
+    base = {
+        "id": "msg_01",
+        "role": "assistant",
+        "model": "claude-opus-5",
+        "content": content,
+        "stop_reason": stop_reason,
+        "stop_details": None,
+        "usage": _usage(),
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _text_block(text):
+    return SimpleNamespace(type="text", text=text)
+
+
+def _tool_block(block_id, name, payload):
+    return SimpleNamespace(type="tool_use", id=block_id, name=name, input=payload)
+
+
+class TestConvertResponse:
+    @pytest.mark.asyncio
+    async def test_text_response(self):
+        message = await AnthropicConverter().convert_response(
+            _response([_text_block("hello")])
+        )
+        assert message.role == "assistant"
+        assert message.content[0].text == "hello"
+        assert message.metadata["provider"] == "anthropic"
+        assert message.metadata["finish_reason"] == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_usage_is_mapped(self):
+        response = _response(
+            [_text_block("hi")],
+            usage=_usage(
+                input_tokens=100,
+                output_tokens=20,
+                cache_read_input_tokens=80,
+                cache_creation_input_tokens=15,
+            ),
+        )
+        message = await AnthropicConverter().convert_response(response)
+        assert message.usages.prompt_tokens == 100
+        assert message.usages.completion_tokens == 20
+        assert message.usages.total_tokens == 120
+        assert message.usages.cache_read_input_tokens == 80
+        assert message.usages.cache_creation_input_tokens == 15
+
+    @pytest.mark.asyncio
+    async def test_missing_usage_does_not_raise(self):
+        message = await AnthropicConverter().convert_response(
+            _response([_text_block("hi")], usage=None)
+        )
+        assert message.usages.total_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_tool_use_becomes_tool_call(self):
+        response = _response(
+            [_tool_block("toolu_1", "get_weather", {"city": "Dhaka"})],
+            stop_reason="tool_use",
+        )
+        message = await AnthropicConverter().convert_response(response)
+        assert message.tools_calls[0]["id"] == "toolu_1"
+        assert message.tools_calls[0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_parallel_tool_calls_are_all_captured(self):
+        response = _response(
+            [
+                _text_block("looking those up"),
+                _tool_block("toolu_1", "a", {"x": 1}),
+                _tool_block("toolu_2", "b", {"y": 2}),
+            ],
+            stop_reason="tool_use",
+        )
+        message = await AnthropicConverter().convert_response(response)
+        assert len(message.tools_calls) == 2
+        assert [c["id"] for c in message.tools_calls] == ["toolu_1", "toolu_2"]
+
+    @pytest.mark.asyncio
+    async def test_thinking_block_becomes_reasoning(self):
+        response = _response(
+            [SimpleNamespace(type="thinking", thinking="step one"), _text_block("answer")]
+        )
+        message = await AnthropicConverter().convert_response(response)
+        assert message.reasoning == "step one"
+
+    @pytest.mark.asyncio
+    async def test_refusal_with_empty_content_does_not_raise(self):
+        """A refusal is a 200 whose content may be empty; never index blindly."""
+        response = _response(
+            [],
+            stop_reason="refusal",
+            stop_details=SimpleNamespace(
+                type="refusal", category="cyber", explanation="declined"
+            ),
+        )
+        message = await AnthropicConverter().convert_response(response)
+        assert message.metadata["refusal"] is True
+        assert message.metadata["refusal_category"] == "cyber"
+        assert message.content[0].text == "declined"
+
+    @pytest.mark.asyncio
+    async def test_non_refusal_does_not_set_refusal_metadata(self):
+        message = await AnthropicConverter().convert_response(
+            _response([_text_block("fine")])
+        )
+        assert "refusal" not in message.metadata
+
+
+class _FakeStream:
+    """Async-iterable stand-in for the SDK stream context manager."""
+
+    def __init__(self, events):
+        self._events = events
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        return False
+
+    def __aiter__(self):
+        async def gen():
+            for event in self._events:
+                yield event
+
+        return gen()
+
+
+def _delta(index, dtype, **fields):
+    return SimpleNamespace(
+        type="content_block_delta",
+        index=index,
+        delta=SimpleNamespace(type=dtype, **fields),
+    )
+
+
+async def _collect(events, converter=None):
+    converter = converter or AnthropicConverter()
+    return [
+        message
+        async for message in converter.convert_streaming_response(
+            {"thread_id": "t1"}, "agent", _FakeStream(events)
+        )
+    ]
+
+
+class TestStreaming:
+    @pytest.mark.asyncio
+    async def test_text_deltas_accumulate_into_final_message(self):
+        events = [
+            SimpleNamespace(
+                type="message_start",
+                message=SimpleNamespace(id="msg_1", model="claude-opus-5", usage=_usage()),
+            ),
+            _delta(0, "text_delta", text="Hel"),
+            _delta(0, "text_delta", text="lo"),
+            SimpleNamespace(type="message_stop"),
+        ]
+        messages = await _collect(events)
+        assert [m.content[0].text for m in messages[:-1]] == ["Hel", "lo"]
+        final = messages[-1]
+        assert final.delta is False
+        assert final.content[0].text == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_chunks_are_marked_as_deltas(self):
+        events = [_delta(0, "text_delta", text="x")]
+        messages = await _collect(events)
+        assert messages[0].delta is True
+        assert messages[-1].delta is False
+
+    @pytest.mark.asyncio
+    async def test_fragmented_tool_json_is_parsed_only_at_block_stop(self):
+        """A partial input_json_delta is not valid JSON on its own."""
+        events = [
+            SimpleNamespace(
+                type="content_block_start",
+                index=0,
+                content_block=SimpleNamespace(type="tool_use", id="toolu_1", name="search"),
+            ),
+            _delta(0, "input_json_delta", partial_json='{"qu'),
+            _delta(0, "input_json_delta", partial_json='ery": "a'),
+            _delta(0, "input_json_delta", partial_json='gentflow"}'),
+            SimpleNamespace(type="content_block_stop", index=0),
+        ]
+        messages = await _collect(events)
+        final = messages[-1]
+        assert len(final.tools_calls) == 1
+        assert final.tools_calls[0]["function"]["arguments"] == '{"query": "agentflow"}'
+        # No tool call was emitted mid-stream from a partial fragment.
+        assert all(m.tools_calls is None for m in messages[:-1])
+
+    @pytest.mark.asyncio
+    async def test_parallel_tool_blocks_are_kept_separate_by_index(self):
+        events = [
+            SimpleNamespace(
+                type="content_block_start",
+                index=0,
+                content_block=SimpleNamespace(type="tool_use", id="t1", name="a"),
+            ),
+            SimpleNamespace(
+                type="content_block_start",
+                index=1,
+                content_block=SimpleNamespace(type="tool_use", id="t2", name="b"),
+            ),
+            _delta(0, "input_json_delta", partial_json='{"x":1}'),
+            _delta(1, "input_json_delta", partial_json='{"y":2}'),
+            SimpleNamespace(type="content_block_stop", index=0),
+            SimpleNamespace(type="content_block_stop", index=1),
+        ]
+        final = (await _collect(events))[-1]
+        assert {c["id"] for c in final.tools_calls} == {"t1", "t2"}
+        arguments = {c["id"]: c["function"]["arguments"] for c in final.tools_calls}
+        assert arguments["t1"] == '{"x":1}'
+        assert arguments["t2"] == '{"y":2}'
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_json_degrades_to_empty_object(self):
+        events = [
+            SimpleNamespace(
+                type="content_block_start",
+                index=0,
+                content_block=SimpleNamespace(type="tool_use", id="t1", name="a"),
+            ),
+            _delta(0, "input_json_delta", partial_json="not json"),
+            SimpleNamespace(type="content_block_stop", index=0),
+        ]
+        final = (await _collect(events))[-1]
+        assert final.tools_calls[0]["function"]["arguments"] == "{}"
+
+    @pytest.mark.asyncio
+    async def test_thinking_deltas_accumulate_into_reasoning(self):
+        events = [
+            _delta(0, "thinking_delta", thinking="first "),
+            _delta(0, "thinking_delta", thinking="second"),
+        ]
+        final = (await _collect(events))[-1]
+        assert final.reasoning == "first second"
+
+    @pytest.mark.asyncio
+    async def test_message_delta_carries_stop_reason_and_usage(self):
+        events = [
+            _delta(0, "text_delta", text="hi"),
+            SimpleNamespace(
+                type="message_delta",
+                delta=SimpleNamespace(stop_reason="max_tokens", stop_details=None),
+                usage=_usage(input_tokens=7, output_tokens=3),
+            ),
+        ]
+        final = (await _collect(events))[-1]
+        assert final.metadata["finish_reason"] == "max_tokens"
+        assert final.usages.prompt_tokens == 7
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_refusal_surfaces_in_metadata(self):
+        events = [
+            SimpleNamespace(
+                type="message_delta",
+                delta=SimpleNamespace(
+                    stop_reason="refusal",
+                    stop_details=SimpleNamespace(category="bio", explanation="no"),
+                ),
+                usage=_usage(),
+            ),
+        ]
+        final = (await _collect(events))[-1]
+        assert final.metadata["refusal"] is True
+        assert final.metadata["refusal_category"] == "bio"
+
+    @pytest.mark.asyncio
+    async def test_empty_stream_still_yields_a_final_message(self):
+        messages = await _collect([])
+        assert len(messages) == 1
+        assert messages[0].delta is False
+
+
+class TestServerToolBlocks:
+    @pytest.mark.asyncio
+    async def test_server_tool_use_is_not_added_to_tools_calls(self):
+        """Anthropic already ran it; the graph must not run it again."""
+        response = _response(
+            [
+                SimpleNamespace(
+                    type="server_tool_use", id="srv_1", name="web_search", input={"query": "x"}
+                ),
+                _text_block("here is what I found"),
+            ]
+        )
+        message = await AnthropicConverter().convert_response(response)
+        assert message.tools_calls is None
+        assert any(
+            getattr(b, "tool_type", None) == "server_tool" for b in message.content
+        )
+
+    @pytest.mark.asyncio
+    async def test_web_search_results_list_is_captured(self):
+        block = SimpleNamespace(
+            type="web_search_tool_result",
+            tool_use_id="srv_1",
+            content=[{"title": "a"}, {"title": "b"}],
+        )
+        message = await AnthropicConverter().convert_response(_response([block]))
+        results = message.metadata["server_tool_results"]
+        assert results[0]["results"] == [{"title": "a"}, {"title": "b"}]
+
+    @pytest.mark.asyncio
+    async def test_web_search_error_object_is_flagged(self):
+        """Server-tool errors arrive as a 200 with an error object, not a raise."""
+        block = SimpleNamespace(
+            type="web_search_tool_result",
+            tool_use_id="srv_1",
+            content=SimpleNamespace(error_code="max_uses_exceeded"),
+        )
+        message = await AnthropicConverter().convert_response(_response([block]))
+        assert message.metadata["server_tool_results"][0]["error_code"] == "max_uses_exceeded"
+
+    @pytest.mark.asyncio
+    async def test_code_execution_result_is_captured(self):
+        block = SimpleNamespace(
+            type="bash_code_execution_tool_result",
+            tool_use_id="srv_2",
+            content=SimpleNamespace(error_code=None),
+        )
+        message = await AnthropicConverter().convert_response(_response([block]))
+        assert message.metadata["server_tool_results"][0]["type"] == (
+            "bash_code_execution_tool_result"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pause_turn_is_flagged_as_resumable(self):
+        response = _response([_text_block("partial")], stop_reason="pause_turn")
+        message = await AnthropicConverter().convert_response(response)
+        assert message.metadata["pause_turn"] is True
+        assert message.metadata["finish_reason"] == "pause_turn"
+
+    @pytest.mark.asyncio
+    async def test_no_server_tools_leaves_metadata_clean(self):
+        message = await AnthropicConverter().convert_response(_response([_text_block("hi")]))
+        assert "server_tool_results" not in message.metadata
+        assert "pause_turn" not in message.metadata

--- a/tests/graph/test_agent_internal.py
+++ b/tests/graph/test_agent_internal.py
@@ -284,7 +284,13 @@ class TestDetectProviderFromModel:
     def test_unknown_prefix_falls_back_to_openai(self):
         agent = _make_openai_agent()
         assert agent._detect_provider_from_model("ollama/llama3") == "openai"
-        assert agent._detect_provider_from_model("anthropic/claude-3") == "openai"
+
+    def test_anthropic_prefix_is_now_recognised(self):
+        """``anthropic``/``claude`` became real prefixes when the native
+        Anthropic provider landed; they no longer fall through to openai."""
+        agent = _make_openai_agent()
+        assert agent._detect_provider_from_model("anthropic/claude-opus-5") == "anthropic"
+        assert agent._detect_provider_from_model("claude-opus-5") == "anthropic"
 
 
 class TestResolveProviderAndModel:
@@ -2027,12 +2033,22 @@ class TestAgentInit:
         assert agent.provider == "openai"
         assert agent.model == "meta-llama/Llama-3-70b"
 
-    def test_anthropic_prefix_resolves_to_openai(self):
-        """Claude via an OpenAI-compatible endpoint should not select google."""
+    def test_anthropic_prefix_resolves_to_anthropic(self):
+        """``anthropic/`` is a recognised prefix now, so it selects the native
+        provider and is stripped from the model name."""
         with patch.object(Agent, "_create_client", return_value=MagicMock()):
-            agent = Agent(model="anthropic/claude-3", reasoning_config=None)
+            agent = Agent(model="anthropic/claude-opus-5", reasoning_config=None)
+        assert agent.provider == "anthropic"
+        assert agent.model == "claude-opus-5"
+
+    def test_explicit_provider_still_routes_claude_through_openai(self):
+        """Escape hatch for Claude behind an OpenAI-compatible proxy, which is
+        what ``anthropic/...`` used to do implicitly before the native provider."""
+        with patch.object(Agent, "_create_client", return_value=MagicMock()):
+            agent = Agent(
+                model="anthropic/claude-3", provider="openai", reasoning_config=None
+            )
         assert agent.provider == "openai"
-        assert agent.model == "anthropic/claude-3"
 
     def test_ollama_prefix_resolves_to_openai(self):
         with patch.object(Agent, "_create_client", return_value=MagicMock()):

--- a/tests/graph/test_anthropic_features.py
+++ b/tests/graph/test_anthropic_features.py
@@ -1,0 +1,299 @@
+"""Tests for prompt caching, count_tokens, server tools, and batches."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentflow.core.graph.agent_internal.anthropic import AgentAnthropicMixin
+from agentflow.core.graph.agent_internal.anthropic_request import (
+    apply_cache_control,
+    strip_bedrock_prefix,
+)
+from agentflow.core.graph.agent_internal.anthropic_server_tools import (
+    CODE_EXECUTION,
+    WEB_FETCH_BASIC,
+    WEB_FETCH_DYNAMIC,
+    WEB_SEARCH_BASIC,
+    WEB_SEARCH_DYNAMIC,
+    code_execution_tool,
+    is_server_tool,
+    web_fetch_tool,
+    web_search_tool,
+)
+from agentflow.core.llm.anthropic_batch import AnthropicBatch, BatchResult
+
+
+class TestStripBedrockPrefix:
+    def test_prefix_removed_for_lookup(self):
+        assert strip_bedrock_prefix("anthropic.claude-opus-5") == "claude-opus-5"
+
+    def test_bare_id_unchanged(self):
+        assert strip_bedrock_prefix("claude-opus-5") == "claude-opus-5"
+
+
+class TestCacheControl:
+    def test_disabled_by_default(self):
+        system = [{"type": "text", "text": "sys"}]
+        apply_cache_control(None, system, None)
+        assert "cache_control" not in system[0]
+
+    def test_false_is_a_noop(self):
+        system = [{"type": "text", "text": "sys"}]
+        apply_cache_control(False, system, None)
+        assert "cache_control" not in system[0]
+
+    def test_true_marks_last_system_block(self):
+        system = [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]
+        apply_cache_control(True, system, None)
+        assert "cache_control" not in system[0]
+        assert system[1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_dict_allows_custom_ttl(self):
+        system = [{"type": "text", "text": "sys"}]
+        apply_cache_control({"type": "ephemeral", "ttl": "1h"}, system, None)
+        assert system[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_tools_get_a_breakpoint_too(self):
+        """Tools render before system, so the tool list is part of the prefix."""
+        tools = [{"name": "a"}, {"name": "b"}]
+        apply_cache_control(True, None, tools)
+        assert "cache_control" not in tools[0]
+        assert tools[1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_no_system_and_no_tools_is_safe(self):
+        apply_cache_control(True, None, None)
+
+
+class _StubAgent(AgentAnthropicMixin):
+    def __init__(self, **overrides):
+        self.model = overrides.get("model", "claude-opus-5")
+        self.llm_kwargs = overrides.get("llm_kwargs", {})
+        self.reasoning_config = overrides.get("reasoning_config")
+        self.output_schema = overrides.get("output_schema")
+        self.client = MagicMock()
+        self.client.messages.create = AsyncMock(
+            return_value=SimpleNamespace(usage=None, stop_reason="end_turn")
+        )
+        self.client.messages.count_tokens = AsyncMock(
+            return_value=SimpleNamespace(input_tokens=1234)
+        )
+
+
+class TestCachingInRequest:
+    @pytest.mark.asyncio
+    async def test_cache_flag_reaches_the_system_block(self):
+        agent = _StubAgent(llm_kwargs={"anthropic_cache": True})
+        await agent._call_anthropic(
+            [{"role": "system", "content": "big prompt"}, {"role": "user", "content": "hi"}]
+        )
+        system = agent.client.messages.create.call_args.kwargs["system"]
+        assert system[-1]["cache_control"] == {"type": "ephemeral"}
+
+    @pytest.mark.asyncio
+    async def test_anthropic_cache_is_not_sent_as_a_request_param(self):
+        agent = _StubAgent(llm_kwargs={"anthropic_cache": True})
+        await agent._call_anthropic([{"role": "user", "content": "hi"}])
+        assert "anthropic_cache" not in agent.client.messages.create.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_explicit_cache_control_is_not_doubled(self):
+        """A caller placing their own breakpoints owns the strategy."""
+        agent = _StubAgent(
+            llm_kwargs={"anthropic_cache": True, "cache_control": {"type": "ephemeral"}}
+        )
+        await agent._call_anthropic(
+            [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}]
+        )
+        system = agent.client.messages.create.call_args.kwargs["system"]
+        assert "cache_control" not in system[-1]
+
+
+class TestCountTokens:
+    @pytest.mark.asyncio
+    async def test_returns_input_tokens(self):
+        agent = _StubAgent()
+        assert await agent._count_tokens_anthropic([{"role": "user", "content": "hi"}]) == 1234
+
+    @pytest.mark.asyncio
+    async def test_generation_params_are_not_sent(self):
+        """count_tokens prices the input; max_tokens et al. are rejected."""
+        agent = _StubAgent(llm_kwargs={"max_tokens": 500}, reasoning_config={"effort": "high"})
+        await agent._count_tokens_anthropic([{"role": "user", "content": "hi"}])
+        kwargs = agent.client.messages.count_tokens.call_args.kwargs
+        for rejected in ("max_tokens", "stream", "output_config", "temperature"):
+            assert rejected not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_counts_against_the_real_payload(self):
+        """System prompt and tools are part of the counted input."""
+        agent = _StubAgent()
+        await agent._count_tokens_anthropic(
+            [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}],
+            tools=[{"type": "function", "function": {"name": "f", "description": "d"}}],
+        )
+        kwargs = agent.client.messages.count_tokens.call_args.kwargs
+        assert kwargs["system"] == [{"type": "text", "text": "sys"}]
+        assert kwargs["tools"][0]["name"] == "f"
+
+    @pytest.mark.asyncio
+    async def test_missing_input_tokens_returns_zero(self):
+        agent = _StubAgent()
+        agent.client.messages.count_tokens = AsyncMock(return_value=SimpleNamespace())
+        assert await agent._count_tokens_anthropic([]) == 0
+
+
+class TestServerTools:
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("claude-opus-5", WEB_SEARCH_DYNAMIC),
+            ("claude-sonnet-5", WEB_SEARCH_DYNAMIC),
+            ("claude-haiku-4-5", WEB_SEARCH_BASIC),
+            ("anthropic.claude-opus-5", WEB_SEARCH_DYNAMIC),
+        ],
+    )
+    def test_web_search_variant_is_model_gated(self, model, expected):
+        assert web_search_tool(model)["type"] == expected
+
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("claude-opus-5", WEB_FETCH_DYNAMIC),
+            ("claude-haiku-4-5", WEB_FETCH_BASIC),
+        ],
+    )
+    def test_web_fetch_variant_is_model_gated(self, model, expected):
+        assert web_fetch_tool(model)["type"] == expected
+
+    def test_optional_params_only_included_when_set(self):
+        tool = web_search_tool("claude-opus-5")
+        assert set(tool) == {"type", "name"}
+
+    def test_domain_filters_are_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="never both"):
+            web_search_tool("claude-opus-5", allowed_domains=["a.test"], blocked_domains=["b.test"])
+
+    def test_web_fetch_domain_filters_are_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="never both"):
+            web_fetch_tool("claude-opus-5", allowed_domains=["a.test"], blocked_domains=["b.test"])
+
+    def test_code_execution_tool_shape(self):
+        assert code_execution_tool() == {"type": CODE_EXECUTION, "name": "code_execution"}
+
+    @pytest.mark.parametrize(
+        ("tool", "expected"),
+        [
+            ({"type": WEB_SEARCH_DYNAMIC, "name": "web_search"}, True),
+            ({"type": CODE_EXECUTION, "name": "code_execution"}, True),
+            ({"type": "function", "function": {"name": "f"}}, False),
+            ("not a dict", False),
+        ],
+    )
+    def test_is_server_tool(self, tool, expected):
+        assert is_server_tool(tool) is expected
+
+    @pytest.mark.asyncio
+    async def test_server_tools_pass_through_conversion_unmangled(self):
+        agent = _StubAgent()
+        search = web_search_tool("claude-opus-5", max_uses=3)
+        await agent._call_anthropic([{"role": "user", "content": "hi"}], tools=[search])
+        assert agent.client.messages.create.call_args.kwargs["tools"] == [search]
+
+
+class TestBatch:
+    def _batch(self):
+        return AnthropicBatch(model="claude-haiku-4-5", client=MagicMock())
+
+    def test_add_translates_system_prompt(self):
+        batch = self._batch()
+        batch.add(
+            "row-1",
+            [{"role": "system", "content": "sys"}, {"role": "user", "content": "q"}],
+        )
+        body = batch.requests[0]["params"]
+        assert body["system"] == [{"type": "text", "text": "sys"}]
+        assert body["messages"] == [{"role": "user", "content": "q"}]
+
+    def test_max_tokens_is_defaulted(self):
+        batch = self._batch()
+        batch.add("row-1", [{"role": "user", "content": "q"}])
+        assert batch.requests[0]["params"]["max_tokens"] == batch.max_tokens
+
+    def test_duplicate_custom_id_is_rejected(self):
+        """custom_id is the only way results are matched back."""
+        batch = self._batch()
+        batch.add("dup", [{"role": "user", "content": "a"}])
+        with pytest.raises(ValueError, match="Duplicate custom_id"):
+            batch.add("dup", [{"role": "user", "content": "b"}])
+
+    def test_add_is_chainable(self):
+        batch = self._batch()
+        assert batch.add("a", [{"role": "user", "content": "1"}]) is batch
+
+    @pytest.mark.asyncio
+    async def test_submit_rejects_an_empty_batch(self):
+        with pytest.raises(ValueError, match="empty batch"):
+            await self._batch().submit()
+
+    @pytest.mark.asyncio
+    async def test_results_are_keyed_by_custom_id_not_position(self):
+        """Batch results come back in any order."""
+        batch = self._batch()
+
+        def entry(custom_id, text):
+            return SimpleNamespace(
+                custom_id=custom_id,
+                result=SimpleNamespace(
+                    type="succeeded",
+                    message=SimpleNamespace(
+                        content=[SimpleNamespace(type="text", text=text)],
+                        stop_reason="end_turn",
+                        usage=SimpleNamespace(input_tokens=5, output_tokens=2),
+                    ),
+                ),
+            )
+
+        async def gen():
+            # Deliberately out of submission order.
+            for item in (entry("row-2", "second"), entry("row-1", "first")):
+                yield item
+
+        batch.client.messages.batches.results = AsyncMock(return_value=gen())
+
+        results = await batch.results("batch_1")
+        assert results["row-1"].text == "first"
+        assert results["row-2"].text == "second"
+        assert results["row-1"].ok
+
+    @pytest.mark.asyncio
+    async def test_errored_entry_is_captured_not_dropped(self):
+        batch = self._batch()
+
+        async def gen():
+            yield SimpleNamespace(
+                custom_id="row-1",
+                result=SimpleNamespace(type="errored", error={"type": "invalid_request"}),
+            )
+
+        batch.client.messages.batches.results = AsyncMock(return_value=gen())
+
+        results = await batch.results("batch_1")
+        assert results["row-1"].status == "errored"
+        assert results["row-1"].ok is False
+        assert results["row-1"].error == {"type": "invalid_request"}
+
+    @pytest.mark.asyncio
+    async def test_wait_times_out_when_batch_never_ends(self):
+        batch = self._batch()
+        batch.client.messages.batches.retrieve = AsyncMock(
+            return_value=SimpleNamespace(processing_status="in_progress")
+        )
+        with pytest.raises(TimeoutError, match="in_progress"):
+            await batch.wait("batch_1", poll_interval=0.01, timeout=0.02)
+
+    def test_batch_result_ok_property(self):
+        assert BatchResult("a", "succeeded").ok is True
+        assert BatchResult("a", "expired").ok is False

--- a/tests/graph/test_anthropic_provider.py
+++ b/tests/graph/test_anthropic_provider.py
@@ -1,0 +1,320 @@
+"""Tests for Anthropic provider detection, client construction, and request assembly."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentflow.core.graph.agent_internal.anthropic import (
+    AgentAnthropicMixin,
+    apply_reasoning_config,
+    strip_rejected_sampling_params,
+)
+from agentflow.core.graph.agent_internal.constants import (
+    ANTHROPIC_DEFAULT_MAX_TOKENS,
+    ANTHROPIC_DEFAULT_MAX_TOKENS_STREAMING,
+)
+from agentflow.core.llm.client_factory import (
+    create_llm_client,
+    detect_provider,
+    resolve_provider_and_model,
+)
+
+
+class TestProviderDetection:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "claude-haiku-4-5",
+            "claude-fable-5",
+            "anthropic/claude-opus-5",
+            "claude/claude-opus-5",
+        ],
+    )
+    def test_claude_models_resolve_to_anthropic(self, model):
+        assert detect_provider(model) == "anthropic"
+
+    def test_bedrock_style_id_resolves_to_anthropic(self):
+        assert detect_provider("anthropic.claude-opus-5") == "anthropic"
+
+    def test_bedrock_prefix_is_preserved_in_model_string(self):
+        """The ``anthropic.`` prefix is part of the Bedrock model id."""
+        provider, model = resolve_provider_and_model("anthropic.claude-opus-5")
+        assert provider == "anthropic"
+        assert model == "anthropic.claude-opus-5"
+
+    def test_recognised_prefix_is_stripped(self):
+        provider, model = resolve_provider_and_model("anthropic/claude-opus-5")
+        assert provider == "anthropic"
+        assert model == "claude-opus-5"
+
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("gpt-4o", "openai"),
+            ("gemini-2.5-flash", "google"),
+            ("openai/gpt-4o", "openai"),
+            ("meta-llama/Llama-3-70b", "openai"),
+        ],
+    )
+    def test_other_providers_are_unaffected(self, model, expected):
+        assert detect_provider(model) == expected
+
+    def test_vertex_flag_does_not_hijack_claude_models(self):
+        """Claude runs on Vertex too. Letting use_vertex_ai force "google" would
+        build a Google client for a Claude model and fail at request time."""
+        assert detect_provider("claude-opus-5", use_vertex_ai=True) == "anthropic"
+
+    @pytest.mark.parametrize("model", ["gemini-2.5-flash", "gpt-4o", "some-unknown-model"])
+    def test_vertex_flag_still_forces_google_for_everything_else(self, model):
+        assert detect_provider(model, use_vertex_ai=True) == "google"
+
+    def test_vertex_flag_selects_the_anthropic_vertex_backend(self, monkeypatch):
+        """The flag means the same thing for Claude as it does for Gemini."""
+        import sys
+        from agentflow.core.graph.agent_internal.providers import AgentProviderMixin
+
+        module = SimpleNamespace(
+            AsyncAnthropic=MagicMock(),
+            AsyncAnthropicVertex=MagicMock(),
+            AsyncAnthropicBedrockMantle=MagicMock(),
+        )
+        monkeypatch.setitem(sys.modules, "anthropic", module)
+
+        agent = AgentProviderMixin()
+        agent.llm_kwargs = {}
+        agent._create_client("anthropic", None, True)
+
+        assert module.AsyncAnthropicVertex.called
+        assert not module.AsyncAnthropic.called
+
+    def test_explicit_backend_beats_the_vertex_flag(self, monkeypatch):
+        import sys
+        from agentflow.core.graph.agent_internal.providers import AgentProviderMixin
+
+        module = SimpleNamespace(
+            AsyncAnthropic=MagicMock(),
+            AsyncAnthropicVertex=MagicMock(),
+            AsyncAnthropicBedrockMantle=MagicMock(),
+        )
+        monkeypatch.setitem(sys.modules, "anthropic", module)
+
+        agent = AgentProviderMixin()
+        agent.llm_kwargs = {"anthropic_backend": "bedrock"}
+        agent._create_client("anthropic", None, True)
+
+        assert module.AsyncAnthropicBedrockMantle.called
+        assert not module.AsyncAnthropicVertex.called
+
+
+class TestClientConstruction:
+    """Client selection per backend, with a stubbed anthropic module."""
+
+    @pytest.fixture
+    def fake_anthropic(self, monkeypatch):
+        module = SimpleNamespace(
+            AsyncAnthropic=MagicMock(name="AsyncAnthropic"),
+            AsyncAnthropicVertex=MagicMock(name="AsyncAnthropicVertex"),
+            AsyncAnthropicBedrockMantle=MagicMock(name="AsyncAnthropicBedrockMantle"),
+        )
+        monkeypatch.setitem(sys.modules, "anthropic", module)
+        return module
+
+    def test_default_backend_builds_direct_client(self, fake_anthropic, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        create_llm_client("anthropic")
+        assert fake_anthropic.AsyncAnthropic.called
+        assert fake_anthropic.AsyncAnthropic.call_args.kwargs["api_key"] == "sk-test"
+
+    def test_vertex_backend_builds_vertex_client(self, fake_anthropic):
+        create_llm_client("anthropic", anthropic_backend="vertex")
+        assert fake_anthropic.AsyncAnthropicVertex.called
+        assert not fake_anthropic.AsyncAnthropic.called
+
+    def test_bedrock_backend_builds_mantle_client(self, fake_anthropic):
+        """Mantle is the Messages-API endpoint; the plain client is legacy."""
+        create_llm_client("anthropic", anthropic_backend="bedrock")
+        assert fake_anthropic.AsyncAnthropicBedrockMantle.called
+
+    def test_unknown_backend_raises(self, fake_anthropic):
+        with pytest.raises(ValueError, match="Unsupported anthropic_backend"):
+            create_llm_client("anthropic", anthropic_backend="azure")
+
+    def test_openai_constructor_keys_are_not_forwarded(self, fake_anthropic, monkeypatch):
+        """``organization``/``project`` are not accepted by AsyncAnthropic."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        create_llm_client("anthropic", organization="org", project="proj", max_retries=4)
+        kwargs = fake_anthropic.AsyncAnthropic.call_args.kwargs
+        assert "organization" not in kwargs
+        assert "project" not in kwargs
+        assert kwargs["max_retries"] == 4
+
+    def test_vertex_accepts_region_and_project(self, fake_anthropic):
+        create_llm_client(
+            "anthropic", anthropic_backend="vertex", region="us-east5", project_id="p1"
+        )
+        kwargs = fake_anthropic.AsyncAnthropicVertex.call_args.kwargs
+        assert kwargs["region"] == "us-east5"
+        assert kwargs["project_id"] == "p1"
+
+    def test_timeout_default_is_applied(self, fake_anthropic, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        create_llm_client("anthropic")
+        assert "timeout" in fake_anthropic.AsyncAnthropic.call_args.kwargs
+
+    def test_missing_sdk_raises_with_install_command(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "anthropic", None)
+        with pytest.raises(ImportError, match=r"10xscale-agentflow\[anthropic\]"):
+            create_llm_client("anthropic")
+
+
+class TestSamplingParamStripping:
+    @pytest.mark.parametrize(
+        "model",
+        ["claude-opus-5", "claude-sonnet-5", "claude-opus-4-8", "claude-fable-5"],
+    )
+    def test_rejected_models_have_sampling_stripped(self, model):
+        kwargs = {"temperature": 0.7, "top_p": 0.9, "top_k": 40, "max_tokens": 100}
+        strip_rejected_sampling_params(model, kwargs)
+        assert kwargs == {"max_tokens": 100}
+
+    def test_older_models_keep_sampling(self):
+        """Not a blanket strip: older models still accept these."""
+        kwargs = {"temperature": 0.7, "max_tokens": 100}
+        strip_rejected_sampling_params("claude-haiku-4-5", kwargs)
+        assert kwargs["temperature"] == 0.7
+
+    def test_bedrock_prefixed_id_is_matched(self):
+        kwargs = {"temperature": 0.5}
+        strip_rejected_sampling_params("anthropic.claude-opus-5", kwargs)
+        assert "temperature" not in kwargs
+
+
+class TestReasoningConfig:
+    def test_effort_maps_to_output_config(self):
+        kwargs: dict = {}
+        apply_reasoning_config({"effort": "high"}, kwargs)
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert kwargs["output_config"] == {"effort": "high"}
+
+    def test_no_reasoning_config_is_a_noop(self):
+        kwargs: dict = {}
+        apply_reasoning_config(None, kwargs)
+        assert kwargs == {}
+
+    def test_budget_tokens_is_never_emitted(self):
+        """budget_tokens returns a 400 on every current Claude model."""
+        kwargs: dict = {}
+        apply_reasoning_config({"thinking_budget": 5000}, kwargs)
+        assert "budget_tokens" not in kwargs
+        assert "thinking_budget" not in kwargs
+        assert kwargs["thinking"] == {"type": "adaptive"}
+
+
+class _StubAgent(AgentAnthropicMixin):
+    """Minimal Agent stand-in exposing only what _call_anthropic touches."""
+
+    def __init__(self, **overrides):
+        self.model = overrides.get("model", "claude-opus-5")
+        self.llm_kwargs = overrides.get("llm_kwargs", {})
+        self.reasoning_config = overrides.get("reasoning_config")
+        self.output_schema = overrides.get("output_schema")
+        self.client = MagicMock()
+        self.client.messages.create = AsyncMock(
+            return_value=SimpleNamespace(usage=SimpleNamespace(cache_read_input_tokens=0))
+        )
+        self.client.messages.stream = MagicMock(return_value="stream-handle")
+
+
+class TestRequestAssembly:
+    @pytest.mark.asyncio
+    async def test_max_tokens_is_injected(self):
+        """Anthropic requires max_tokens on every request."""
+        agent = _StubAgent()
+        await agent._call_anthropic([{"role": "user", "content": "hi"}])
+        kwargs = agent.client.messages.create.call_args.kwargs
+        assert kwargs["max_tokens"] == ANTHROPIC_DEFAULT_MAX_TOKENS
+
+    @pytest.mark.asyncio
+    async def test_streaming_gets_a_larger_max_tokens_default(self):
+        agent = _StubAgent()
+        await agent._call_anthropic([{"role": "user", "content": "hi"}], stream=True)
+        kwargs = agent.client.messages.stream.call_args.kwargs
+        assert kwargs["max_tokens"] == ANTHROPIC_DEFAULT_MAX_TOKENS_STREAMING
+
+    @pytest.mark.asyncio
+    async def test_explicit_max_tokens_wins(self):
+        agent = _StubAgent(llm_kwargs={"max_tokens": 512})
+        await agent._call_anthropic([{"role": "user", "content": "hi"}])
+        assert agent.client.messages.create.call_args.kwargs["max_tokens"] == 512
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_is_lifted_out_of_messages(self):
+        agent = _StubAgent()
+        await agent._call_anthropic(
+            [
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": "hi"},
+            ]
+        )
+        kwargs = agent.client.messages.create.call_args.kwargs
+        assert kwargs["system"] == [{"type": "text", "text": "be terse"}]
+        assert all(m["role"] != "system" for m in kwargs["messages"])
+
+    @pytest.mark.asyncio
+    async def test_trailing_assistant_turn_is_dropped(self):
+        """Guards the injected context_summary, which 400s as a prefill."""
+        agent = _StubAgent()
+        await agent._call_anthropic(
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "summary"},
+            ]
+        )
+        messages = agent.client.messages.create.call_args.kwargs["messages"]
+        assert messages[-1]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_sampling_params_stripped_for_rejecting_model(self):
+        agent = _StubAgent(model="claude-opus-5", llm_kwargs={"temperature": 0.7})
+        await agent._call_anthropic([{"role": "user", "content": "hi"}])
+        assert "temperature" not in agent.client.messages.create.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_tools_are_converted_to_anthropic_shape(self):
+        agent = _StubAgent()
+        await agent._call_anthropic(
+            [{"role": "user", "content": "hi"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "f", "description": "d", "parameters": {}},
+                }
+            ],
+        )
+        tools = agent.client.messages.create.call_args.kwargs["tools"]
+        assert tools[0]["name"] == "f"
+        assert "input_schema" in tools[0]
+
+    @pytest.mark.asyncio
+    async def test_excluded_kwargs_are_not_sent_as_request_params(self):
+        agent = _StubAgent(
+            llm_kwargs={"api_key": "sk-x", "anthropic_backend": "vertex", "timeout": 5}
+        )
+        await agent._call_anthropic([{"role": "user", "content": "hi"}])
+        kwargs = agent.client.messages.create.call_args.kwargs
+        for leaked in ("api_key", "anthropic_backend", "timeout"):
+            assert leaked not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_reasoning_config_reaches_the_request(self):
+        agent = _StubAgent(reasoning_config={"effort": "xhigh"})
+        await agent._call_anthropic([{"role": "user", "content": "hi"}])
+        kwargs = agent.client.messages.create.call_args.kwargs
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert kwargs["output_config"]["effort"] == "xhigh"

--- a/tests/graph/test_anthropic_request.py
+++ b/tests/graph/test_anthropic_request.py
@@ -1,0 +1,328 @@
+"""Tests for pure Anthropic request translation.
+
+Everything here runs without a client, a network call, or an AgentState: the
+module under test is deliberately side-effect free so the message and tool
+mapping (the hard part) can be covered exhaustively.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from agentflow.core.graph.agent_internal.anthropic_request import (
+    convert_assistant_tool_calls,
+    convert_content_parts,
+    convert_tools,
+    drop_trailing_assistant,
+    merge_tool_results,
+    split_system,
+)
+
+
+class TestSplitSystem:
+    def test_no_system_prompt_returns_none(self):
+        messages = [{"role": "user", "content": "hi"}]
+        system, remainder = split_system(messages)
+        assert system is None
+        assert remainder == messages
+
+    def test_single_system_prompt_extracted(self):
+        messages = [
+            {"role": "system", "content": "be terse"},
+            {"role": "user", "content": "hi"},
+        ]
+        system, remainder = split_system(messages)
+        assert system == [{"type": "text", "text": "be terse"}]
+        assert remainder == [{"role": "user", "content": "hi"}]
+
+    def test_many_system_prompts_become_block_list(self):
+        """Kept as separate blocks: that list is the cache_control attach point."""
+        messages = [
+            {"role": "system", "content": "first"},
+            {"role": "system", "content": "second"},
+            {"role": "user", "content": "hi"},
+        ]
+        system, remainder = split_system(messages)
+        assert system == [
+            {"type": "text", "text": "first"},
+            {"type": "text", "text": "second"},
+        ]
+        assert len(remainder) == 1
+
+    def test_structured_system_content(self):
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": "block form"}]},
+        ]
+        system, _ = split_system(messages)
+        assert system == [{"type": "text", "text": "block form"}]
+
+    def test_empty_system_content_is_dropped(self):
+        messages = [{"role": "system", "content": ""}, {"role": "user", "content": "hi"}]
+        system, remainder = split_system(messages)
+        assert system is None
+        assert len(remainder) == 1
+
+
+class TestMergeToolResults:
+    def test_single_tool_result_becomes_user_message(self):
+        messages = [
+            {"role": "tool", "tool_call_id": "call_1", "content": "42"},
+        ]
+        merged = merge_tool_results(messages)
+        assert merged == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "call_1", "content": "42"}
+                ],
+            }
+        ]
+
+    def test_parallel_tool_results_collapse_into_one_turn(self):
+        """The whole point: splitting these degrades parallel tool calling."""
+        messages = [
+            {"role": "tool", "tool_call_id": "call_1", "content": "a"},
+            {"role": "tool", "tool_call_id": "call_2", "content": "b"},
+            {"role": "tool", "tool_call_id": "call_3", "content": "c"},
+        ]
+        merged = merge_tool_results(messages)
+        assert len(merged) == 1
+        assert merged[0]["role"] == "user"
+        assert [b["tool_use_id"] for b in merged[0]["content"]] == [
+            "call_1",
+            "call_2",
+            "call_3",
+        ]
+
+    def test_failed_call_marked_is_error(self):
+        messages = [
+            {"role": "tool", "tool_call_id": "c1", "content": "boom", "is_error": True},
+            {"role": "tool", "tool_call_id": "c2", "content": "ok"},
+        ]
+        merged = merge_tool_results(messages)
+        blocks = merged[0]["content"]
+        assert blocks[0]["is_error"] is True
+        assert "is_error" not in blocks[1]
+
+    def test_interleaved_assistant_turns_split_the_groups(self):
+        messages = [
+            {"role": "tool", "tool_call_id": "c1", "content": "a"},
+            {"role": "assistant", "content": "thinking"},
+            {"role": "tool", "tool_call_id": "c2", "content": "b"},
+        ]
+        merged = merge_tool_results(messages)
+        assert [m["role"] for m in merged] == ["user", "assistant", "user"]
+        assert merged[0]["content"][0]["tool_use_id"] == "c1"
+        assert merged[2]["content"][0]["tool_use_id"] == "c2"
+
+    def test_ordering_is_preserved(self):
+        messages = [
+            {"role": "user", "content": "q"},
+            {"role": "tool", "tool_call_id": "c1", "content": "a"},
+        ]
+        merged = merge_tool_results(messages)
+        assert [m["role"] for m in merged] == ["user", "user"]
+
+    def test_assistant_tool_calls_become_tool_use_blocks(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "search", "arguments": '{"q": "x"}'},
+                    }
+                ],
+            }
+        ]
+        merged = merge_tool_results(messages)
+        block = merged[0]["content"][0]
+        assert block["type"] == "tool_use"
+        assert block["id"] == "call_1"
+        assert block["name"] == "search"
+        assert block["input"] == {"q": "x"}
+
+    def test_empty_input_is_unchanged(self):
+        assert merge_tool_results([]) == []
+
+
+class TestConvertAssistantToolCalls:
+    def test_arguments_are_parsed_not_string_matched(self):
+        """Claude varies JSON escaping; arguments must go through a real parser."""
+        message = {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "function": {
+                        "name": "f",
+                        "arguments": '{"path": "a\\/b", "n": 1}',
+                    },
+                }
+            ],
+        }
+        result = convert_assistant_tool_calls(message)
+        assert result["content"][0]["input"] == {"path": "a/b", "n": 1}
+
+    def test_malformed_arguments_degrade_to_empty_dict(self):
+        message = {
+            "role": "assistant",
+            "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "not json"}}],
+        }
+        result = convert_assistant_tool_calls(message)
+        assert result["content"][0]["input"] == {}
+
+    def test_text_content_precedes_tool_use_blocks(self):
+        message = {
+            "role": "assistant",
+            "content": "let me check",
+            "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+        }
+        result = convert_assistant_tool_calls(message)
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][1]["type"] == "tool_use"
+
+    def test_dict_arguments_pass_through(self):
+        message = {
+            "role": "assistant",
+            "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": {"a": 1}}}],
+        }
+        result = convert_assistant_tool_calls(message)
+        assert result["content"][0]["input"] == {"a": 1}
+
+
+class TestConvertTools:
+    def test_openai_shape_is_unwrapped(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Look up weather",
+                    "parameters": {"type": "object", "properties": {"city": {}}},
+                },
+            }
+        ]
+        assert convert_tools(tools) == [
+            {
+                "name": "get_weather",
+                "description": "Look up weather",
+                "input_schema": {"type": "object", "properties": {"city": {}}},
+            }
+        ]
+
+    def test_already_anthropic_shaped_tool_passes_through(self):
+        """Server tools must not be mangled."""
+        tools = [{"type": "web_search_20260209", "name": "web_search", "max_uses": 3}]
+        assert convert_tools(tools) == tools
+
+    def test_strict_is_lifted_to_top_level(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "f", "description": "", "strict": True},
+            }
+        ]
+        assert convert_tools(tools)[0]["strict"] is True
+
+    def test_missing_parameters_gets_empty_object_schema(self):
+        tools = [{"type": "function", "function": {"name": "f", "description": "d"}}]
+        assert convert_tools(tools)[0]["input_schema"] == {
+            "type": "object",
+            "properties": {},
+        }
+
+    @pytest.mark.parametrize("empty", [None, []])
+    def test_empty_tools_returns_none(self, empty):
+        assert convert_tools(empty) is None
+
+
+class TestConvertContentParts:
+    def test_plain_string_passes_through(self):
+        assert convert_content_parts("hello") == "hello"
+
+    def test_text_part(self):
+        assert convert_content_parts([{"type": "text", "text": "hi"}]) == [
+            {"type": "text", "text": "hi"}
+        ]
+
+    def test_remote_image_url_becomes_url_source(self):
+        parts = [{"type": "image_url", "image_url": {"url": "https://x.test/a.png"}}]
+        assert convert_content_parts(parts) == [
+            {"type": "image", "source": {"type": "url", "url": "https://x.test/a.png"}}
+        ]
+
+    def test_data_uri_image_becomes_base64_source(self):
+        payload = base64.standard_b64encode(b"png-bytes").decode()
+        parts = [
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{payload}"},
+            }
+        ]
+        assert convert_content_parts(parts) == [
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": payload,
+                },
+            }
+        ]
+
+    def test_document_with_extracted_text_degrades_to_text(self):
+        parts = [{"type": "document", "document": {"text": "already extracted"}}]
+        assert convert_content_parts(parts) == [
+            {"type": "text", "text": "already extracted"}
+        ]
+
+    def test_pdf_url_becomes_document_block(self):
+        parts = [{"type": "document", "document": {"url": "https://x.test/a.pdf"}}]
+        assert convert_content_parts(parts) == [
+            {"type": "document", "source": {"type": "url", "url": "https://x.test/a.pdf"}}
+        ]
+
+    @pytest.mark.parametrize("ptype", ["input_audio", "video"])
+    def test_unsupported_media_is_dropped(self, ptype):
+        """Anthropic has no equivalent; degrade rather than invent a failure."""
+        parts = [{"type": "text", "text": "keep"}, {"type": ptype, ptype: {"url": "u"}}]
+        assert convert_content_parts(parts) == [{"type": "text", "text": "keep"}]
+
+    def test_image_with_no_url_is_dropped(self):
+        parts = [{"type": "image_url", "image_url": {}}]
+        assert convert_content_parts(parts) == []
+
+    def test_unknown_part_passes_through(self):
+        parts = [{"type": "thinking", "thinking": "..."}]
+        assert convert_content_parts(parts) == parts
+
+
+class TestDropTrailingAssistant:
+    def test_trailing_assistant_is_dropped(self):
+        """Prefill returns a 400 on every current Claude model."""
+        messages = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "summary"},
+        ]
+        assert drop_trailing_assistant(messages) == [{"role": "user", "content": "q"}]
+
+    def test_trailing_user_is_kept(self):
+        messages = [{"role": "user", "content": "q"}]
+        assert drop_trailing_assistant(messages) == messages
+
+    def test_empty_list_is_safe(self):
+        assert drop_trailing_assistant([]) == []
+
+    def test_only_the_last_assistant_is_dropped(self):
+        messages = [
+            {"role": "assistant", "content": "earlier"},
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "trailing"},
+        ]
+        result = drop_trailing_assistant(messages)
+        assert len(result) == 2
+        assert result[0]["content"] == "earlier"

--- a/tests/graph/test_provider_parity.py
+++ b/tests/graph/test_provider_parity.py
@@ -1,0 +1,236 @@
+"""Tests for cross-provider parity: count_tokens and the batch helpers.
+
+The point of these is that the *surface* is the same across providers even
+where the underlying APIs differ, so switching providers does not mean
+relearning the interface.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentflow.core.graph.agent_internal.google import AgentGoogleMixin
+from agentflow.core.llm import AnthropicBatch, BatchResult, OpenAIBatch
+from agentflow.core.llm.openai_batch import normalise_status
+
+
+class _GoogleStub(AgentGoogleMixin):
+    def __init__(self):
+        self.model = "gemini-2.5-flash"
+        self.llm_kwargs = {}
+        self.client = MagicMock()
+        self.client.aio.models.count_tokens = AsyncMock(
+            return_value=SimpleNamespace(total_tokens=321)
+        )
+
+
+class TestGoogleCountTokens:
+    @pytest.mark.asyncio
+    async def test_returns_total_tokens(self):
+        agent = _GoogleStub()
+        assert await agent._count_tokens_google([{"role": "user", "content": "hi"}]) == 321
+
+    @pytest.mark.asyncio
+    async def test_counts_against_converted_contents(self):
+        """Uses the same conversion the real request does, not the raw dicts."""
+        agent = _GoogleStub()
+        await agent._count_tokens_google([{"role": "user", "content": "hi"}])
+        kwargs = agent.client.aio.models.count_tokens.call_args.kwargs
+        assert kwargs["model"] == "gemini-2.5-flash"
+        assert kwargs["contents"]  # converted Content objects, not plain dicts
+
+    @pytest.mark.asyncio
+    async def test_missing_total_returns_zero(self):
+        agent = _GoogleStub()
+        agent.client.aio.models.count_tokens = AsyncMock(return_value=SimpleNamespace())
+        assert await agent._count_tokens_google([]) == 0
+
+
+class TestBatchSurfaceParity:
+    """Both helpers expose the same methods and return the same result type."""
+
+    @pytest.mark.parametrize("method", ["add", "submit", "status", "wait", "results"])
+    def test_same_methods_on_both(self, method):
+        assert hasattr(AnthropicBatch, method)
+        assert hasattr(OpenAIBatch, method)
+
+    def test_both_reject_duplicate_custom_ids(self):
+        for batch in (
+            AnthropicBatch(model="claude-haiku-4-5", client=MagicMock()),
+            OpenAIBatch(model="gpt-4o-mini", client=MagicMock()),
+        ):
+            batch.add("dup", [{"role": "user", "content": "a"}])
+            with pytest.raises(ValueError, match="Duplicate custom_id"):
+                batch.add("dup", [{"role": "user", "content": "b"}])
+
+    @pytest.mark.asyncio
+    async def test_both_reject_an_empty_batch(self):
+        for batch in (
+            AnthropicBatch(model="claude-haiku-4-5", client=MagicMock()),
+            OpenAIBatch(model="gpt-4o-mini", client=MagicMock()),
+        ):
+            with pytest.raises(ValueError, match="empty batch"):
+                await batch.submit()
+
+    def test_both_chain_from_add(self):
+        for batch in (
+            AnthropicBatch(model="claude-haiku-4-5", client=MagicMock()),
+            OpenAIBatch(model="gpt-4o-mini", client=MagicMock()),
+        ):
+            assert batch.add("a", [{"role": "user", "content": "1"}]) is batch
+
+
+def _openai_batch():
+    return OpenAIBatch(model="gpt-4o-mini", client=MagicMock())
+
+
+class TestOpenAIBatch:
+    def test_request_uses_openai_jsonl_envelope(self):
+        batch = _openai_batch()
+        batch.add("row-1", [{"role": "user", "content": "q"}])
+        entry = batch.requests[0]
+        assert entry["method"] == "POST"
+        assert entry["url"] == "/v1/chat/completions"
+        assert entry["body"]["model"] == "gpt-4o-mini"
+
+    def test_messages_need_no_translation(self):
+        """agentflow's internal dialect is already OpenAI-shaped."""
+        messages = [{"role": "system", "content": "sys"}, {"role": "user", "content": "q"}]
+        batch = _openai_batch()
+        batch.add("row-1", messages)
+        assert batch.requests[0]["body"]["messages"] == messages
+
+    def test_jsonl_is_one_object_per_line(self):
+        batch = _openai_batch()
+        batch.add("a", [{"role": "user", "content": "1"}])
+        batch.add("b", [{"role": "user", "content": "2"}])
+        lines = batch._to_jsonl().decode().splitlines()
+        assert len(lines) == 2
+        assert [json.loads(line)["custom_id"] for line in lines] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_submit_uploads_then_creates(self):
+        batch = _openai_batch()
+        batch.add("row-1", [{"role": "user", "content": "q"}])
+        batch.client.files.create = AsyncMock(return_value=SimpleNamespace(id="file_1"))
+        batch.client.batches.create = AsyncMock(return_value=SimpleNamespace(id="batch_1"))
+
+        assert await batch.submit() == "batch_1"
+        assert batch.client.batches.create.call_args.kwargs["input_file_id"] == "file_1"
+
+    @pytest.mark.asyncio
+    async def test_results_are_keyed_by_custom_id_not_position(self):
+        batch = _openai_batch()
+
+        def line(custom_id, text):
+            return json.dumps(
+                {
+                    "custom_id": custom_id,
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "choices": [
+                                {"message": {"content": text}, "finish_reason": "stop"}
+                            ],
+                            "usage": {"prompt_tokens": 5, "completion_tokens": 2},
+                        },
+                    },
+                }
+            )
+
+        batch.client.batches.retrieve = AsyncMock(
+            return_value=SimpleNamespace(status="completed", output_file_id="out_1")
+        )
+        # Deliberately out of submission order.
+        batch.client.files.content = AsyncMock(
+            return_value=SimpleNamespace(text=f"{line('row-2', 'second')}\n{line('row-1', 'first')}")
+        )
+
+        results = await batch.results("batch_1")
+        assert results["row-1"].text == "first"
+        assert results["row-2"].text == "second"
+        assert results["row-1"].input_tokens == 5
+        assert results["row-1"].ok
+
+    @pytest.mark.asyncio
+    async def test_per_entry_error_is_captured_not_dropped(self):
+        batch = _openai_batch()
+        batch.client.batches.retrieve = AsyncMock(
+            return_value=SimpleNamespace(status="completed", output_file_id="out_1")
+        )
+        batch.client.files.content = AsyncMock(
+            return_value=SimpleNamespace(
+                text=json.dumps(
+                    {"custom_id": "row-1", "error": {"message": "bad request"}, "response": None}
+                )
+            )
+        )
+
+        results = await batch.results("batch_1")
+        assert results["row-1"].status == "errored"
+        assert results["row-1"].ok is False
+
+    @pytest.mark.asyncio
+    async def test_http_error_status_marks_the_entry_failed(self):
+        batch = _openai_batch()
+        batch.client.batches.retrieve = AsyncMock(
+            return_value=SimpleNamespace(status="completed", output_file_id="out_1")
+        )
+        batch.client.files.content = AsyncMock(
+            return_value=SimpleNamespace(
+                text=json.dumps(
+                    {
+                        "custom_id": "row-1",
+                        "response": {"status_code": 429, "body": {"error": "rate limited"}},
+                    }
+                )
+            )
+        )
+
+        results = await batch.results("batch_1")
+        assert results["row-1"].status == "errored"
+
+    @pytest.mark.asyncio
+    async def test_no_output_file_returns_empty_rather_than_raising(self):
+        """A failed or expired batch has no output file to download."""
+        batch = _openai_batch()
+        batch.client.batches.retrieve = AsyncMock(
+            return_value=SimpleNamespace(status="failed", output_file_id=None)
+        )
+        assert await batch.results("batch_1") == {}
+
+    @pytest.mark.asyncio
+    async def test_wait_stops_on_every_terminal_status(self):
+        """Not just 'completed' — a failed batch must not poll forever."""
+        batch = _openai_batch()
+        batch.client.batches.retrieve = AsyncMock(
+            return_value=SimpleNamespace(status="failed", output_file_id=None)
+        )
+        assert await batch.wait("batch_1", poll_interval=0.01, timeout=1) == {}
+
+    @pytest.mark.asyncio
+    async def test_wait_times_out_while_in_progress(self):
+        batch = _openai_batch()
+        batch.client.batches.retrieve = AsyncMock(
+            return_value=SimpleNamespace(status="in_progress")
+        )
+        with pytest.raises(TimeoutError, match="in_progress"):
+            await batch.wait("batch_1", poll_interval=0.01, timeout=0.02)
+
+    @pytest.mark.parametrize(
+        ("openai_status", "expected"),
+        [("cancelled", "canceled"), ("failed", "errored"), ("completed", "completed")],
+    )
+    def test_status_vocabulary_is_normalised(self, openai_status, expected):
+        assert normalise_status(openai_status) == expected
+
+
+class TestSharedBatchResult:
+    def test_both_helpers_return_the_same_type(self):
+        assert BatchResult("a", "succeeded").ok is True
+        assert BatchResult("a", "errored").ok is False
+        assert BatchResult("a", "expired").ok is False

--- a/tests/utils/test_call_llm.py
+++ b/tests/utils/test_call_llm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,7 +20,9 @@ from agentflow.core.llm.caller import (
 # Provider dispatch
 # ---------------------------------------------------------------------------
 
-_DETECT = "agentflow.core.llm.caller.detect_provider"
+# call_llm resolves provider *and* model together, so a recognised
+# "provider/" prefix is stripped before the name reaches the SDK.
+_RESOLVE = "agentflow.core.llm.caller.resolve_provider_and_model"
 _CREATE = "agentflow.core.llm.caller.create_llm_client"
 _CALL_GOOGLE = "agentflow.core.llm.caller._call_google"
 _CALL_RESP = "agentflow.core.llm.caller._call_openai_responses"
@@ -31,7 +34,7 @@ _DUMMY = ("text", 10, 5, 0)
 @pytest.mark.anyio
 async def test_google_model_dispatches_to_google():
     with (
-        patch(_DETECT, return_value="google"),
+        patch(_RESOLVE, return_value=("google", "test-model")),
         patch(_CREATE, return_value=MagicMock()),
         patch(_CALL_GOOGLE, new=AsyncMock(return_value=_DUMMY)) as mock,
     ):
@@ -44,7 +47,7 @@ async def test_google_model_dispatches_to_google():
 @pytest.mark.anyio
 async def test_openai_default_dispatches_to_responses():
     with (
-        patch(_DETECT, return_value="openai"),
+        patch(_RESOLVE, return_value=("openai", "test-model")),
         patch(_CREATE, return_value=MagicMock()),
         patch(_CALL_RESP, new=AsyncMock(return_value=_DUMMY)) as mock,
     ):
@@ -57,7 +60,7 @@ async def test_openai_default_dispatches_to_responses():
 @pytest.mark.anyio
 async def test_openai_chat_style_dispatches_to_chat():
     with (
-        patch(_DETECT, return_value="openai"),
+        patch(_RESOLVE, return_value=("openai", "test-model")),
         patch(_CREATE, return_value=MagicMock()),
         patch(_CALL_CHAT, new=AsyncMock(return_value=_DUMMY)) as mock,
     ):
@@ -71,7 +74,7 @@ async def test_openai_chat_style_dispatches_to_chat():
 async def test_openai_responses_style_explicit():
     """Explicitly passing api_style='responses' still hits the Responses path."""
     with (
-        patch(_DETECT, return_value="openai"),
+        patch(_RESOLVE, return_value=("openai", "test-model")),
         patch(_CREATE, return_value=MagicMock()),
         patch(_CALL_RESP, new=AsyncMock(return_value=_DUMMY)) as mock_resp,
         patch(_CALL_CHAT, new=AsyncMock(return_value=_DUMMY)) as mock_chat,
@@ -86,7 +89,7 @@ async def test_openai_responses_style_explicit():
 async def test_api_style_irrelevant_for_google():
     """api_style has no effect when the provider is Google."""
     with (
-        patch(_DETECT, return_value="google"),
+        patch(_RESOLVE, return_value=("google", "test-model")),
         patch(_CREATE, return_value=MagicMock()),
         patch(_CALL_GOOGLE, new=AsyncMock(return_value=_DUMMY)) as mock_google,
         patch(_CALL_CHAT, new=AsyncMock(return_value=_DUMMY)) as mock_chat,
@@ -104,7 +107,7 @@ async def test_api_style_irrelevant_for_google():
 @pytest.mark.anyio
 async def test_system_prompt_forwarded_to_responses():
     with (
-        patch(_DETECT, return_value="openai"),
+        patch(_RESOLVE, return_value=("openai", "test-model")),
         patch(_CREATE, return_value=MagicMock()),
         patch(_CALL_RESP, new=AsyncMock(return_value=_DUMMY)) as mock,
     ):
@@ -118,7 +121,7 @@ async def test_system_prompt_forwarded_to_responses():
 @pytest.mark.anyio
 async def test_system_prompt_forwarded_to_chat():
     with (
-        patch(_DETECT, return_value="openai"),
+        patch(_RESOLVE, return_value=("openai", "test-model")),
         patch(_CREATE, return_value=MagicMock()),
         patch(_CALL_CHAT, new=AsyncMock(return_value=_DUMMY)) as mock,
     ):
@@ -293,3 +296,102 @@ async def test_call_openai_chat_implementation():
     assert kwargs["temperature"] == 0.8
     assert kwargs["response_format"] == {"type": "json_object"}
     assert kwargs["another_param"] == "another_val"
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+_CALL_ANTHROPIC = "agentflow.core.llm.caller._call_anthropic"
+
+
+@pytest.mark.anyio
+async def test_claude_model_dispatches_to_anthropic():
+    with (
+        patch(_RESOLVE, return_value=("anthropic", "claude-opus-5")),
+        patch(_CREATE, return_value=MagicMock()),
+        patch(_CALL_ANTHROPIC, new=AsyncMock(return_value=_DUMMY)) as mock,
+    ):
+        result = await call_llm("claude-opus-5", "hello")
+
+    mock.assert_called_once()
+    assert result == _DUMMY
+
+
+@pytest.mark.anyio
+async def test_anthropic_drops_temperature_for_rejecting_models():
+    """call_llm defaults temperature=0.3; current Claude models 400 on it."""
+    from agentflow.core.llm.caller import _call_anthropic
+
+    client = MagicMock()
+    client.messages.create = AsyncMock(
+        return_value=SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="hi")],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=3, output_tokens=1, cache_read_input_tokens=0),
+        )
+    )
+
+    await _call_anthropic(
+        client,
+        "claude-opus-5",
+        "hello",
+        system_prompt=None,
+        max_tokens=100,
+        temperature=0.3,
+        json_mode=False,
+    )
+    assert "temperature" not in client.messages.create.call_args.kwargs
+
+
+@pytest.mark.anyio
+async def test_anthropic_keeps_temperature_for_older_models():
+    from agentflow.core.llm.caller import _call_anthropic
+
+    client = MagicMock()
+    client.messages.create = AsyncMock(
+        return_value=SimpleNamespace(content=[], stop_reason="end_turn", usage=None)
+    )
+
+    await _call_anthropic(
+        client,
+        "claude-haiku-4-5",
+        "hello",
+        system_prompt=None,
+        max_tokens=100,
+        temperature=0.3,
+        json_mode=False,
+    )
+    assert client.messages.create.call_args.kwargs["temperature"] == 0.3
+
+
+@pytest.mark.anyio
+async def test_anthropic_returns_text_and_usage():
+    from agentflow.core.llm.caller import _call_anthropic
+
+    client = MagicMock()
+    client.messages.create = AsyncMock(
+        return_value=SimpleNamespace(
+            content=[
+                SimpleNamespace(type="thinking", thinking="ignored"),
+                SimpleNamespace(type="text", text="  answer  "),
+            ],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(
+                input_tokens=42, output_tokens=7, cache_read_input_tokens=30
+            ),
+        )
+    )
+
+    text, inp, out, cache = await _call_anthropic(
+        client,
+        "claude-opus-5",
+        "hello",
+        system_prompt="be terse",
+        max_tokens=100,
+        temperature=0.3,
+        json_mode=False,
+    )
+    assert text == "answer"
+    assert (inp, out, cache) == (42, 7, 30)
+    assert client.messages.create.call_args.kwargs["system"] == "be terse"


### PR DESCRIPTION
This pull request introduces native Anthropic Claude support to the codebase, making Claude models first-class citizens alongside OpenAI and Google providers. It updates documentation, installation instructions, and the core agent implementation to support Anthropic's APIs, including advanced features like server tools, prompt caching, and token counting. The changes also clarify provider selection, add new extras for Anthropic backends, and correct prior documentation that implied but did not provide native Claude support.

**Major Anthropic Claude Integration**

- Added a native Anthropic provider to the agent, supporting direct Claude API, Vertex AI, and Bedrock backends, with automatic parameter handling and support for streaming, tool calling, multimodal input, prompt caching, and server tools. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR27-R103) [[2]](diffhunk://#diff-652a2893cfd97a17941a46f66eafba1cd1d3768b02d51c7be7b848c3012059e1R1-R228) [[3]](diffhunk://#diff-966944a75f24a797e49633924627d273f6edbb19c36f965ec2f91009d1f52ab1R17) [[4]](diffhunk://#diff-966944a75f24a797e49633924627d273f6edbb19c36f965ec2f91009d1f52ab1R36)
- Implemented Anthropic-specific request helpers and mixins in `agentflow/core/graph/agent_internal/anthropic.py`, including request assembly, parameter mapping, and token counting.

**Documentation and Installation Updates**

- Updated documentation (`README.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `CONTRIBUTING.md`) to reflect native Anthropic support, new extras (`anthropic`, `anthropic-vertex`, `anthropic-bedrock`, `all`), and correct prior misleading statements about Claude support. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L40-R40) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L112-R134) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L160-R178) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L179-L180) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R122) [[6]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L30-R30) [[7]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R58-R60)

**Provider Detection and Selection Improvements**

- Enhanced provider detection logic to recognize `anthropic/` and `claude/` model prefixes, and clarified the use of the `anthropic_backend` selector for different Claude backends. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR27-R103) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L112-R134)

**Bug Fixes and Breaking Changes**

- Fixed issues where `use_vertex_ai=True` incorrectly routed Claude models to Google GenAI, and where model prefixes were not stripped before sending requests.
- Introduced breaking changes: `anthropic/` and `claude/` prefixes now select the native Anthropic provider by default; explicit provider override is required to use OpenAI-compatible endpoints.

**Extras and Development Workflow**

- Added new install extras for Anthropic providers and updated development/CI workflows to include Anthropic in editable installs. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L160-R178) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L30-R30) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R122) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R58-R60)

These changes make Anthropic Claude models fully supported and configurable, improve the clarity and accuracy of documentation, and ensure provider selection is robust and explicit.